### PR TITLE
Allow bot to trade only with money earned from trade/giving by admins.

### DIFF
--- a/conf/mod_ahbot.conf.dist
+++ b/conf/mod_ahbot.conf.dist
@@ -39,6 +39,15 @@
 #        Number of Items to Add/Remove from the AH during mass operations
 #    Default 200
 #
+#   AuctionHouseBot.NoGoldGeneration
+#       Makes the bot not generate any gold. It will keep track of sales and only buy from players if he has enough gold.
+#       The starting gold of the bot can be set by adding gold to the character
+#   Default 0 (False)
+#
+#   AuctionHouseBot.GoldWalletID
+#       Wallet ID to track money for buying or selling
+#   Default 0 
+#
 ###############################################################################
 
 AuctionHouseBot.DEBUG = 0
@@ -50,6 +59,8 @@ AuctionHouseBot.UseBuyPriceForBuyer = 0
 AuctionHouseBot.Account = 0
 AuctionHouseBot.GUID = 0
 AuctionHouseBot.ItemsPerCycle = 200
+AuctionHouseBot.NoGoldGeneration = 0
+AuctionHouseBot.GoldWalletID = 0
 
 ###############################################################################
 # AUCTION HOUSE BOT FILTERS PART 1

--- a/sql/world/base/mod_auctionhousebot.sql
+++ b/sql/world/base/mod_auctionhousebot.sql
@@ -65,6 +65,16 @@ CREATE TABLE `mod_auctionhousebot` (
   PRIMARY KEY (`auctionhouse`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 
+DROP TABLE IF EXISTS `mod_auctionhousebot_gold`;
+CREATE TABLE `mod_auctionhousebot_gold` (
+`id` int(11) NOT NULL DEFAULT '0' COMMENT 'Wallet ID',
+`gold` bigint(8) unsigned NOT NULL DEFAULT '0' COMMENT 'Gold in wallet',
+PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+INSERT INTO `mod_auctionhousebot_gold` (`id`, `gold`)
+VALUES (0, 20000);
+
 DROP TABLE IF EXISTS `mod_auctionhousebot_disabled_items`;
 CREATE TABLE `mod_auctionhousebot_disabled_items` (
   `item` mediumint(8) unsigned NOT NULL,

--- a/src/AuctionHouseBot.h
+++ b/src/AuctionHouseBot.h
@@ -1162,6 +1162,7 @@ private:
     uint32 AHBplayerAccount;
     uint32 AHBplayerGUID;
     uint32 ItemsPerCycle;
+    bool UseAHBplayerGold;
 
     //Begin Filters
 
@@ -1229,6 +1230,9 @@ private:
     time_t _lastrun_h;
     time_t _lastrun_n;
 
+    //Gold
+    uint32 WalletID;
+
     inline uint32 minValue(uint32 a, uint32 b) { return a <= b ? a : b; };
     void addNewAuctions(Player *AHBplayer, AHBConfig *config);
     void addNewAuctionBuyerBotBid(Player *AHBplayer, AHBConfig *config, WorldSession *session);
@@ -1251,7 +1255,11 @@ public:
     void DecrementItemCounts(AuctionEntry* ah, uint32 itemEntry);
     void IncrementItemCounts(AuctionEntry* ah);
     void Commands(uint32, uint32, uint32, char*);
+    bool GetUseAHBplayerGold() const { return UseAHBplayerGold; }
     uint32 GetAHBplayerGUID() { return AHBplayerGUID; };
+    void AHBotChangeMoney(int32 amount);
+    bool AHBotHasEnoughMoney(uint32 amount);
+    uint64 AHBotGetCurrentMoney();
 };
 
 #define auctionbot AuctionHouseBot::instance()


### PR DESCRIPTION
Changes the buying process to take into account the gold that the bot currently owns. This allows admins to stop bot abuse to generate enormous sums of gold by selling items.
There is already a measure in place by limiting the bids per X time, but this takes it a step further by not generating any more gold (unless the admins add funds to the account) while also removing some form the economy (cuts).