### PR TITLE
Indentation fix

### DIFF
--- a/src/AuctionHouseBot.cpp
+++ b/src/AuctionHouseBot.cpp
@@ -707,7 +707,7 @@ void AuctionHouseBot::Update()
     if ((!AHBSeller) && (!AHBBuyer))
         return;
 
-	WorldSession _session(AHBplayerAccount, NULL, SEC_PLAYER, sWorld->getIntConfig(CONFIG_EXPANSION), 0, LOCALE_zhCN,0,false,false,0);
+    WorldSession _session(AHBplayerAccount, NULL, SEC_PLAYER, sWorld->getIntConfig(CONFIG_EXPANSION), 0, LOCALE_zhCN,0,false,false,0);
     Player _AHBplayer(&_session);
     _AHBplayer.Initialize(AHBplayerGUID);
     sObjectAccessor->AddObject(&_AHBplayer);


### PR DESCRIPTION
After this commit:
https://github.com/azerothcore/azerothcore-wotlk/commit/d2cc3fcbc2d7bf0b185eb03d169afc9783870568

Docker build is failing with indentation error. This updates resolved the error for me.

Tested on Centos 7