### PR TITLE
Refactor AHBot command passing

### DIFF
--- a/src/AuctionHouseBot.cpp
+++ b/src/AuctionHouseBot.cpp
@@ -1508,7 +1508,7 @@ void AuctionHouseBot::DecrementItemCounts(AuctionEntry* ah, uint32 itemEntry)
     config->DecItemCounts(prototype->Class, prototype->Quality);
 }
 
-void AuctionHouseBot::Commands(uint32 command, uint32 ahMapID, uint32 col, char* args)
+void AuctionHouseBot::Commands(AHBotCommand command, uint32 ahMapID, uint32 col, char* args)
 {
     AHBConfig *config = NULL;
     switch (ahMapID)
@@ -1552,7 +1552,7 @@ void AuctionHouseBot::Commands(uint32 command, uint32 ahMapID, uint32 col, char*
     }
     switch (command)
     {
-    case 0:     //ahexpire
+    case AHBotCommand::ahexpire:
         {
             AuctionHouseObject* auctionHouse =  sAuctionMgr->GetAuctionsMap(config->GetAHFID());
 
@@ -1572,7 +1572,7 @@ void AuctionHouseBot::Commands(uint32 command, uint32 ahMapID, uint32 col, char*
             }
         }
         break;
-    case 1:     //min items
+    case AHBotCommand::minitems:
         {
             char * param1 = strtok(args, " ");
             uint32 minItems = (uint32) strtoul(param1, NULL, 0);
@@ -1580,7 +1580,7 @@ void AuctionHouseBot::Commands(uint32 command, uint32 ahMapID, uint32 col, char*
             config->SetMinItems(minItems);
         }
         break;
-    case 2:     //max items
+    case AHBotCommand::maxitems:
         {
             char * param1 = strtok(args, " ");
             uint32 maxItems = (uint32) strtoul(param1, NULL, 0);
@@ -1589,11 +1589,7 @@ void AuctionHouseBot::Commands(uint32 command, uint32 ahMapID, uint32 col, char*
             config->CalculatePercents();
         }
         break;
-    case 3:     //min time Deprecated (Place holder for future commands)
-        break;
-    case 4:     //max time Deprecated (Place holder for future commands)
-        break;
-    case 5:     //percentages
+    case AHBotCommand::percentages:
         {
             char * param1 = strtok(args, " ");
             char * param2 = strtok(NULL, " ");
@@ -1643,7 +1639,7 @@ void AuctionHouseBot::Commands(uint32 command, uint32 ahMapID, uint32 col, char*
             config->SetPercentages(greytg, whitetg, greentg, bluetg, purpletg, orangetg, yellowtg, greyi, whitei, greeni, bluei, purplei, orangei, yellowi);
         }
         break;
-    case 6:     //min prices
+    case AHBotCommand::minprice:
         {
             char * param1 = strtok(args, " ");
             uint32 minPrice = (uint32) strtoul(param1, NULL, 0);
@@ -1651,7 +1647,7 @@ void AuctionHouseBot::Commands(uint32 command, uint32 ahMapID, uint32 col, char*
             config->SetMinPrice(col, minPrice);
         }
         break;
-    case 7:     //max prices
+    case AHBotCommand::maxprice:
         {
             char * param1 = strtok(args, " ");
             uint32 maxPrice = (uint32) strtoul(param1, NULL, 0);
@@ -1659,7 +1655,7 @@ void AuctionHouseBot::Commands(uint32 command, uint32 ahMapID, uint32 col, char*
             config->SetMaxPrice(col, maxPrice);
         }
         break;
-    case 8:     //min bid price
+    case AHBotCommand::minbidprice:
         {
             char * param1 = strtok(args, " ");
             uint32 minBidPrice = (uint32) strtoul(param1, NULL, 0);
@@ -1667,7 +1663,7 @@ void AuctionHouseBot::Commands(uint32 command, uint32 ahMapID, uint32 col, char*
             config->SetMinBidPrice(col, minBidPrice);
         }
         break;
-    case 9:     //max bid price
+    case AHBotCommand::maxbidprice:
         {
             char * param1 = strtok(args, " ");
             uint32 maxBidPrice = (uint32) strtoul(param1, NULL, 0);
@@ -1675,7 +1671,7 @@ void AuctionHouseBot::Commands(uint32 command, uint32 ahMapID, uint32 col, char*
             config->SetMaxBidPrice(col, maxBidPrice);
         }
         break;
-    case 10:        //max stacks
+    case AHBotCommand::maxstack:
         {
             char * param1 = strtok(args, " ");
             uint32 maxStack = (uint32) strtoul(param1, NULL, 0);
@@ -1683,7 +1679,7 @@ void AuctionHouseBot::Commands(uint32 command, uint32 ahMapID, uint32 col, char*
             config->SetMaxStack(col, maxStack);
         }
         break;
-    case 11:        //buyer bid prices
+    case AHBotCommand::buyerprice:
         {
             char * param1 = strtok(args, " ");
             uint32 buyerPrice = (uint32) strtoul(param1, NULL, 0);
@@ -1691,7 +1687,7 @@ void AuctionHouseBot::Commands(uint32 command, uint32 ahMapID, uint32 col, char*
             config->SetBuyerPrice(col, buyerPrice);
         }
         break;
-    case 12:        //buyer bidding interval
+    case AHBotCommand::bidinterval:
         {
             char * param1 = strtok(args, " ");
             uint32 bidInterval = (uint32) strtoul(param1, NULL, 0);
@@ -1699,7 +1695,7 @@ void AuctionHouseBot::Commands(uint32 command, uint32 ahMapID, uint32 col, char*
             config->SetBiddingInterval(bidInterval);
         }
         break;
-    case 13:        //buyer bids per interval
+    case AHBotCommand::bidsperinterval:
         {
             char * param1 = strtok(args, " ");
             uint32 bidsPerInterval = (uint32) strtoul(param1, NULL, 0);

--- a/src/AuctionHouseBot.h
+++ b/src/AuctionHouseBot.h
@@ -27,6 +27,22 @@ struct AuctionEntry;
 class Player;
 class WorldSession;
 
+enum class AHBotCommand : uint32
+{
+    ahexpire,
+    minitems,
+    maxitems,
+    percentages,
+    minprice,
+    maxprice,
+    minbidprice,
+    maxbidprice,
+    maxstack,
+    buyerprice,
+    bidinterval,
+    bidsperinterval
+};
+
 #include "ItemTemplate.h"
 
 #define AHB_GREY        0
@@ -1251,7 +1267,7 @@ public:
     void LoadValues(AHBConfig*);
     void DecrementItemCounts(AuctionEntry* ah, uint32 itemEntry);
     void IncrementItemCounts(AuctionEntry* ah);
-    void Commands(uint32, uint32, uint32, char*);
+    void Commands(AHBotCommand, uint32, uint32, char*);
     ObjectGuid::LowType GetAHBplayerGUID() { return AHBplayerGUID; };
 };
 

--- a/src/cs_ah_bot.cpp
+++ b/src/cs_ah_bot.cpp
@@ -53,6 +53,26 @@ public:
         char* opt = strtok((char*)args, " ");
         char* ahMapIdStr = strtok(NULL, " ");
 
+        auto qualityStringToEnum = [](const char* qualityName, int maxCount)
+        {
+            if (strncmp(qualityName, "grey", maxCount) == 0)
+                return ITEM_QUALITY_POOR;
+            else if (strncmp(qualityName, "white", maxCount) == 0)
+                return ITEM_QUALITY_NORMAL;
+            else if (strncmp(qualityName, "green", maxCount) == 0)
+                return ITEM_QUALITY_UNCOMMON;
+            else if (strncmp(qualityName, "blue", maxCount) == 0)
+                return ITEM_QUALITY_RARE;
+            else if (strncmp(qualityName, "purple", maxCount) == 0)
+                return ITEM_QUALITY_EPIC;
+            else if (strncmp(qualityName, "orange", maxCount) == 0)
+                return ITEM_QUALITY_LEGENDARY;
+            else if (strncmp(qualityName, "yellow", maxCount) == 0)
+                return ITEM_QUALITY_ARTIFACT;
+
+            return static_cast<ItemQualities>(-1); // Invalid
+        };
+
         if (ahMapIdStr)
         {
             ahMapID = uint32(strtoul(ahMapIdStr, NULL, 0));
@@ -94,6 +114,7 @@ public:
             handler->PSendSysMessage("buyerprice");
             handler->PSendSysMessage("bidinterval");
             handler->PSendSysMessage("bidsperinterval");
+            handler->PSendSysMessage("reload");
             return true;
         }
         else if (strncmp(opt, "ahexpire", l) == 0)
@@ -104,7 +125,7 @@ public:
                 return false;
             }
 
-            auctionbot->Commands(0, ahMapID, 0, NULL);
+            auctionbot->Commands(AHBotCommand::ahexpire, ahMapID, 0, NULL);
         }
         else if (strncmp(opt, "minitems", l) == 0)
         {
@@ -115,7 +136,7 @@ public:
                 return false;
             }
 
-            auctionbot->Commands(1, ahMapID, 0, param1);
+            auctionbot->Commands(AHBotCommand::minitems, ahMapID, 0, param1);
         }
         else if (strncmp(opt, "maxitems", l) == 0)
         {
@@ -126,37 +147,7 @@ public:
                 return false;
             }
 
-            auctionbot->Commands(2, ahMapID, 0, param1);
-        }
-        else if (strncmp(opt, "mintime", l) == 0)
-        {
-            handler->PSendSysMessage("ahbotoptions mintime has been deprecated");
-            return false;
-            /*
-            char* param1 = strtok(NULL, " ");
-            if (!ahMapIdStr || !param1)
-            {
-                PSendSysMessage("Syntax is: ahbotoptions mintime $ahMapID (2, 6 or 7) $mintime");
-                return false;
-            }
-
-            auctionbot.Commands(3, ahMapID, 0, param1);
-            */
-        }
-        else if (strncmp(opt, "maxtime", l) == 0)
-        {
-            handler->PSendSysMessage("ahbotoptions maxtime has been deprecated");
-            return false;
-            /*
-            char* param1 = strtok(NULL, " ");
-            if (!ahMapIdStr || !param1)
-            {
-                PSendSysMessage("Syntax is: ahbotoptions maxtime $ahMapID (2, 6 or 7) $maxtime");
-                return false;
-            }
-
-            auctionbot.Commands(4, ahMapID, 0, param1);
-            */
+            auctionbot->Commands(AHBotCommand::maxitems, ahMapID, 0, param1);
         }
         else if (strncmp(opt, "percentages", l) == 0)
         {
@@ -240,7 +231,7 @@ public:
             strcat(param, param13);
             strcat(param, " ");
             strcat(param, param14);
-            auctionbot->Commands(5, ahMapID, 0, param);
+            auctionbot->Commands(AHBotCommand::percentages, ahMapID, 0, param);
         }
         else if (strncmp(opt, "minprice", l) == 0)
         {
@@ -253,20 +244,9 @@ public:
                 return false;
             }
 
-            if (strncmp(param1, "grey", l) == 0)
-                auctionbot->Commands(6, ahMapID, AHB_GREY, param2);
-            else if (strncmp(param1, "white", l) == 0)
-                auctionbot->Commands(6, ahMapID, AHB_WHITE, param2);
-            else if (strncmp(param1, "green", l) == 0)
-                auctionbot->Commands(6, ahMapID, AHB_GREEN, param2);
-            else if (strncmp(param1, "blue", l) == 0)
-                auctionbot->Commands(6, ahMapID, AHB_BLUE, param2);
-            else if (strncmp(param1, "purple", l) == 0)
-                auctionbot->Commands(6, ahMapID, AHB_PURPLE, param2);
-            else if (strncmp(param1, "orange", l) == 0)
-                auctionbot->Commands(6, ahMapID, AHB_ORANGE, param2);
-            else if (strncmp(param1, "yellow", l) == 0)
-                auctionbot->Commands(6, ahMapID, AHB_YELLOW, param2);
+            auto quality = qualityStringToEnum(param1, l);
+            if (quality != static_cast<ItemQualities>(-1))
+                auctionbot->Commands(AHBotCommand::minprice, ahMapID, quality, param2);
             else
             {
                 handler->PSendSysMessage("Syntax is: ahbotoptions minprice $ahMapID (2, 6 or 7) $color (grey, white, green, blue, purple, orange or yellow) $price");
@@ -282,20 +262,10 @@ public:
                 handler->PSendSysMessage("Syntax is: ahbotoptions maxprice $ahMapID (2, 6 or 7) $color (grey, white, green, blue, purple, orange or yellow) $price");
                 return false;
             }
-            if (strncmp(param1, "grey", l) == 0)
-                auctionbot->Commands(7, ahMapID, AHB_GREY, param2);
-            else if (strncmp(param1, "white", l) == 0)
-                auctionbot->Commands(7, ahMapID, AHB_WHITE, param2);
-            else if (strncmp(param1, "green", l) == 0)
-                auctionbot->Commands(7, ahMapID, AHB_GREEN, param2);
-            else if (strncmp(param1, "blue", l) == 0)
-                auctionbot->Commands(7, ahMapID, AHB_BLUE, param2);
-            else if (strncmp(param1, "purple", l) == 0)
-                auctionbot->Commands(7, ahMapID, AHB_PURPLE, param2);
-            else if (strncmp(param1, "orange",l) == 0)
-                auctionbot->Commands(7, ahMapID, AHB_ORANGE, param2);
-            else if (strncmp(param1, "yellow", l) == 0)
-                auctionbot->Commands(7, ahMapID, AHB_YELLOW, param2);
+
+            auto quality = qualityStringToEnum(param1, l);
+            if (quality != static_cast<ItemQualities>(-1))
+                auctionbot->Commands(AHBotCommand::maxprice, ahMapID, quality, param2);
             else
             {
                 handler->PSendSysMessage("Syntax is: ahbotoptions maxprice $ahMapID (2, 6 or 7) $color (grey, white, green, blue, purple, orange or yellow) $price");
@@ -320,20 +290,9 @@ public:
                 return false;
             }
 
-            if (strncmp(param1, "grey", l) == 0)
-                auctionbot->Commands(8, ahMapID, AHB_GREY, param2);
-            else if (strncmp(param1, "white", l) == 0)
-                auctionbot->Commands(8, ahMapID, AHB_WHITE, param2);
-            else if (strncmp(param1, "green", l) == 0)
-                auctionbot->Commands(8, ahMapID, AHB_GREEN, param2);
-            else if (strncmp(param1, "blue", l) == 0)
-                auctionbot->Commands(8, ahMapID, AHB_BLUE, param2);
-            else if (strncmp(param1, "purple", l) == 0)
-                auctionbot->Commands(8, ahMapID, AHB_PURPLE, param2);
-            else if (strncmp(param1, "orange", l) == 0)
-                auctionbot->Commands(8, ahMapID, AHB_ORANGE, param2);
-            else if (strncmp(param1, "yellow", l) == 0)
-                auctionbot->Commands(8, ahMapID, AHB_YELLOW, param2);
+            auto quality = qualityStringToEnum(param1, l);
+            if (quality != static_cast<ItemQualities>(-1))
+                auctionbot->Commands(AHBotCommand::minbidprice, ahMapID, quality, param2);
             else
             {
                 handler->PSendSysMessage("Syntax is: ahbotoptions minbidprice $ahMapID (2, 6 or 7) $color (grey, white, green, blue, purple, orange or yellow) $price");
@@ -358,20 +317,9 @@ public:
                 return false;
             }
 
-            if (strncmp(param1, "grey", l) == 0)
-                auctionbot->Commands(9, ahMapID, AHB_GREY, param2);
-            else if (strncmp(param1, "white", l) == 0)
-                auctionbot->Commands(9, ahMapID, AHB_WHITE, param2);
-            else if (strncmp(param1, "green", l) == 0)
-                auctionbot->Commands(9, ahMapID, AHB_GREEN, param2);
-            else if (strncmp(param1, "blue", l) == 0)
-                auctionbot->Commands(9, ahMapID, AHB_BLUE, param2);
-            else if (strncmp(param1, "purple", l) == 0)
-                auctionbot->Commands(9, ahMapID, AHB_PURPLE, param2);
-            else if (strncmp(param1, " orange", l) == 0)
-                auctionbot->Commands(9, ahMapID, AHB_ORANGE, param2);
-            else if (strncmp(param1, "yellow", l) == 0)
-                auctionbot->Commands(9, ahMapID, AHB_YELLOW, param2);
+            auto quality = qualityStringToEnum(param1, l);
+            if (quality != static_cast<ItemQualities>(-1))
+                auctionbot->Commands(AHBotCommand::maxbidprice, ahMapID, quality, param2);
             else
             {
                 handler->PSendSysMessage("Syntax is: ahbotoptions max bidprice $ahMapID (2, 6 or 7) $color (grey, white, green, blue, purple, orange or yellow) $price");
@@ -396,20 +344,9 @@ public:
             //    return false;
             // }
 
-            if (strncmp(param1, "grey",l) == 0)
-                auctionbot->Commands(10, ahMapID, AHB_GREY, param2);
-            else if (strncmp(param1, "white", l) == 0)
-                auctionbot->Commands(10, ahMapID, AHB_WHITE, param2);
-            else if (strncmp(param1, "green", l) == 0)
-                auctionbot->Commands(10, ahMapID, AHB_GREEN, param2);
-            else if (strncmp(param1, "blue", l) == 0)
-                auctionbot->Commands(10, ahMapID, AHB_BLUE, param2);
-            else if (strncmp(param1, "purple", l) == 0)
-                auctionbot->Commands(10, ahMapID, AHB_PURPLE, param2);
-            else if (strncmp(param1, "orange", l) == 0)
-                auctionbot->Commands(10, ahMapID, AHB_ORANGE, param2);
-            else if (strncmp(param1, "yellow", l) == 0)
-                auctionbot->Commands(10, ahMapID, AHB_YELLOW, param2);
+            auto quality = qualityStringToEnum(param1, l);
+            if (quality != static_cast<ItemQualities>(-1))
+                auctionbot->Commands(AHBotCommand::maxstack, ahMapID, quality, param2);
             else
             {
                 handler->PSendSysMessage("Syntax is: ahbotoptions maxstack $ahMapID (2, 6 or 7) $color (grey, white, green, blue, purple, orange or yellow) $value");
@@ -427,20 +364,9 @@ public:
                 return false;
             }
 
-            if (strncmp(param1, "grey", l) == 0)
-                auctionbot->Commands(11, ahMapID, AHB_GREY, param2);
-            else if (strncmp(param1, "white", l) == 0)
-                auctionbot->Commands(11, ahMapID, AHB_WHITE, param2);
-            else if (strncmp(param1, "green", l) == 0)
-                auctionbot->Commands(11, ahMapID, AHB_GREEN, param2);
-            else if (strncmp(param1, "blue", l) == 0)
-                auctionbot->Commands(11, ahMapID, AHB_BLUE, param2);
-            else if (strncmp(param1, "purple", l) == 0)
-                auctionbot->Commands(11, ahMapID, AHB_PURPLE, param2);
-            else if (strncmp(param1, "orange", l) == 0)
-                auctionbot->Commands(11, ahMapID, AHB_ORANGE, param2);
-            else if (strncmp(param1, "yellow", l) == 0)
-                auctionbot->Commands(11, ahMapID, AHB_YELLOW, param2);
+            auto quality = qualityStringToEnum(param1, l);
+            if (quality != static_cast<ItemQualities>(-1))
+                auctionbot->Commands(AHBotCommand::buyerprice, ahMapID, quality, param2);
             else
             {
                 handler->PSendSysMessage("Syntax is: ahbotoptions buyerprice $ahMapID (2, 6 or 7) $color (grey, white, green, blue or purple) $price");
@@ -457,7 +383,7 @@ public:
                 return false;
             }
 
-            auctionbot->Commands(12, ahMapID, 0, param1);
+            auctionbot->Commands(AHBotCommand::bidinterval, ahMapID, 0, param1);
         }
         else if (strncmp(opt, "bidsperinterval", l) == 0)
         {
@@ -469,7 +395,7 @@ public:
                 return false;
             }
 
-            auctionbot->Commands(13, ahMapID, 0, param1);
+            auctionbot->Commands(AHBotCommand::bidsperinterval, ahMapID, 0, param1);
         }
         else
         {

--- a/src/cs_ah_bot.cpp
+++ b/src/cs_ah_bot.cpp
@@ -57,17 +57,17 @@ public:
         {
             if (strncmp(qualityName, "grey", maxCount) == 0)
                 return ITEM_QUALITY_POOR;
-            else if (strncmp(qualityName, "white", maxCount) == 0)
+            if (strncmp(qualityName, "white", maxCount) == 0)
                 return ITEM_QUALITY_NORMAL;
-            else if (strncmp(qualityName, "green", maxCount) == 0)
+            if (strncmp(qualityName, "green", maxCount) == 0)
                 return ITEM_QUALITY_UNCOMMON;
-            else if (strncmp(qualityName, "blue", maxCount) == 0)
+            if (strncmp(qualityName, "blue", maxCount) == 0)
                 return ITEM_QUALITY_RARE;
-            else if (strncmp(qualityName, "purple", maxCount) == 0)
+            if (strncmp(qualityName, "purple", maxCount) == 0)
                 return ITEM_QUALITY_EPIC;
-            else if (strncmp(qualityName, "orange", maxCount) == 0)
+            if (strncmp(qualityName, "orange", maxCount) == 0)
                 return ITEM_QUALITY_LEGENDARY;
-            else if (strncmp(qualityName, "yellow", maxCount) == 0)
+            if (strncmp(qualityName, "yellow", maxCount) == 0)
                 return ITEM_QUALITY_ARTIFACT;
 
             return static_cast<ItemQualities>(-1); // Invalid


### PR DESCRIPTION
Refactor the way commands are passed.
Instead of passing a magic number and writing a comment of what it means, pass an enum.
Instead of copy-pasting the quality level parsing code, make it a lambda function.


This could still be done much cleaner, but its a first step.

It should be refactored to use command tables, some other time.