### PR TITLE
Store percentages as floats

### DIFF
--- a/data/sql/db-world/updates/01_FloatPercentages.sql
+++ b/data/sql/db-world/updates/01_FloatPercentages.sql
@@ -1,0 +1,15 @@
+ALTER TABLE `mod_auctionhousebot` 
+MODIFY COLUMN `percentgreytradegoods` float(11) NULL DEFAULT 0 COMMENT 'Sets the percentage of the Grey Trade Goods auction items' AFTER `maxitems`,
+MODIFY COLUMN `percentwhitetradegoods` float(11) NULL DEFAULT 27 COMMENT 'Sets the percentage of the White Trade Goods auction items' AFTER `percentgreytradegoods`,
+MODIFY COLUMN `percentgreentradegoods` float(11) NULL DEFAULT 12 COMMENT 'Sets the percentage of the Green Trade Goods auction items' AFTER `percentwhitetradegoods`,
+MODIFY COLUMN `percentbluetradegoods` float(11) NULL DEFAULT 10 COMMENT 'Sets the percentage of the Blue Trade Goods auction items' AFTER `percentgreentradegoods`,
+MODIFY COLUMN `percentpurpletradegoods` float(11) NULL DEFAULT 1 COMMENT 'Sets the percentage of the Purple Trade Goods auction items' AFTER `percentbluetradegoods`,
+MODIFY COLUMN `percentorangetradegoods` float(11) NULL DEFAULT 0 COMMENT 'Sets the percentage of the Orange Trade Goods auction items' AFTER `percentpurpletradegoods`,
+MODIFY COLUMN `percentyellowtradegoods` float(11) NULL DEFAULT 0 COMMENT 'Sets the percentage of the Yellow Trade Goods auction items' AFTER `percentorangetradegoods`,
+MODIFY COLUMN `percentgreyitems` float(11) NULL DEFAULT 0 COMMENT 'Sets the percentage of the non trade Grey auction items' AFTER `percentyellowtradegoods`,
+MODIFY COLUMN `percentwhiteitems` float(11) NULL DEFAULT 10 COMMENT 'Sets the percentage of the non trade White auction items' AFTER `percentgreyitems`,
+MODIFY COLUMN `percentgreenitems` float(11) NULL DEFAULT 30 COMMENT 'Sets the percentage of the non trade Green auction items' AFTER `percentwhiteitems`,
+MODIFY COLUMN `percentblueitems` float(11) NULL DEFAULT 8 COMMENT 'Sets the percentage of the non trade Blue auction items' AFTER `percentgreenitems`,
+MODIFY COLUMN `percentpurpleitems` float(11) NULL DEFAULT 2 COMMENT 'Sets the percentage of the non trade Purple auction items' AFTER `percentblueitems`,
+MODIFY COLUMN `percentorangeitems` float(11) NULL DEFAULT 0 COMMENT 'Sets the percentage of the non trade Orange auction items' AFTER `percentpurpleitems`,
+MODIFY COLUMN `percentyellowitems` float(11) NULL DEFAULT 0 COMMENT 'Sets the percentage of the non trade Yellow auction items' AFTER `percentorangeitems`;

--- a/src/AuctionHouseBot.cpp
+++ b/src/AuctionHouseBot.cpp
@@ -712,22 +712,22 @@ void AuctionHouseBot::Commands(uint32 command, uint32 ahMapID, uint32 col, char*
             char * param12 = strtok(NULL, " ");
             char * param13 = strtok(NULL, " ");
             char * param14 = strtok(NULL, " ");
-            uint32 greytg = (uint32) strtoul(param1, NULL, 0);
-            uint32 whitetg = (uint32) strtoul(param2, NULL, 0);
-            uint32 greentg = (uint32) strtoul(param3, NULL, 0);
-            uint32 bluetg = (uint32) strtoul(param4, NULL, 0);
-            uint32 purpletg = (uint32) strtoul(param5, NULL, 0);
-            uint32 orangetg = (uint32) strtoul(param6, NULL, 0);
-            uint32 yellowtg = (uint32) strtoul(param7, NULL, 0);
-            uint32 greyi = (uint32) strtoul(param8, NULL, 0);
-            uint32 whitei = (uint32) strtoul(param9, NULL, 0);
-            uint32 greeni = (uint32) strtoul(param10, NULL, 0);
-            uint32 bluei = (uint32) strtoul(param11, NULL, 0);
-            uint32 purplei = (uint32) strtoul(param12, NULL, 0);
-            uint32 orangei = (uint32) strtoul(param13, NULL, 0);
-            uint32 yellowi = (uint32) strtoul(param14, NULL, 0);
+            float greytg =  strtof(param1, NULL);
+            float whitetg = strtof(param2, NULL);
+            float greentg = strtof(param3, NULL);
+            float bluetg = strtof(param4, NULL);
+            float purpletg = strtof(param5, NULL);
+            float orangetg = strtof(param6, NULL);
+            float yellowtg = strtof(param7, NULL);
+            float greyi = strtof(param8, NULL);
+            float whitei = strtof(param9, NULL);
+            float greeni = strtof(param10, NULL);
+            float bluei = strtof(param11, NULL);
+            float purplei = strtof(param12, NULL);
+            float orangei = strtof(param13, NULL);
+            float yellowi = strtof(param14, NULL);
 
-            std::array<uint32, AHB_MAX_QUALITY> percentages =
+            std::array<float, AHB_MAX_QUALITY> percentages =
             {
                 greytg, whitetg, greentg, bluetg, purpletg, orangetg, yellowtg, greyi, whitei, greeni, bluei, purplei, orangei, yellowi
             };
@@ -853,8 +853,8 @@ void AuctionHouseBot::LoadValues(AHBConfig* config)
             maxstackgrey, maxstackwhite, maxstackgreen, maxstackblue, maxstackpurple, maxstackorange, maxstackyellow,
             auctionName]
             = result->FetchTuple<uint32, uint32,
-            uint32, uint32, uint32, uint32, uint32, uint32, uint32,
-            uint32, uint32, uint32, uint32, uint32, uint32, uint32,
+            float, float, float, float, float, float, float,
+            float, float, float, float, float, float, float,
             uint32, uint32, uint32, uint32, uint32, uint32, uint32,
             uint32, uint32, uint32, uint32, uint32, uint32, uint32,
             uint32, uint32, uint32, uint32, uint32, uint32, uint32,
@@ -866,10 +866,10 @@ void AuctionHouseBot::LoadValues(AHBConfig* config)
 		config->SetMinItems(minitems);
 		config->SetMaxItems(maxitems);
 
-        std::array<uint32, AHB_MAX_QUALITY> percetages = { percentgreytradegoods, percentwhitetradegoods, percentgreentradegoods, percentbluetradegoods, percentpurpletradegoods, percentorangetradegoods, percentyellowtradegoods,
+        std::array<float, AHB_MAX_QUALITY> percentages = { percentgreytradegoods, percentwhitetradegoods, percentgreentradegoods, percentbluetradegoods, percentpurpletradegoods, percentorangetradegoods, percentyellowtradegoods,
             percentgreyitems, percentwhiteitems, percentgreenitems, percentblueitems, percentpurpleitems, percentorangeitems, percentyellowitems };
 
-        config->SetPercentages(percetages);
+        config->SetPercentages(percentages);
 
         // Load min and max prices
 		config->SetMinPrice(ITEM_QUALITY_POOR, minpricegrey);

--- a/src/AuctionHouseBotConfig.h
+++ b/src/AuctionHouseBotConfig.h
@@ -75,7 +75,7 @@ public:
         return _maxItems;
     }
 
-    void SetPercentages(std::array<uint32, AHB_MAX_QUALITY>& percentages);
+    void SetPercentages(std::array<float, AHB_MAX_QUALITY>& percentages);
 
     uint32 GetPercentages(uint32 color);
 
@@ -161,7 +161,7 @@ private:
     Minutes _buyerBiddingInterval{ 0min };
     uint32 _buyerBidsPerInterval{ 0 };
 
-    std::array<uint32, AHB_MAX_QUALITY> _itemsPercent{};
+    std::array<float, AHB_MAX_QUALITY> _itemsPercent{};
     std::array<uint32, AHB_MAX_QUALITY> _itemsPercentages{};
     std::array<uint32, AHB_DEFAULT_QUALITY_SIZE> _buyerPrice{};
     std::array<uint32, AHB_DEFAULT_QUALITY_SIZE> _maxStack{};


### PR DESCRIPTION
I have one Artifact quality level item I want to be sold.
If I set percentage to the minimum possible value (1%) that means the AH bot wants to sell 90 of these items, and sells tons of this supposed to be rare item.

With percentages as float it can be set to 0.1%. I also made it round up so a 0.1% doesn't end up with zero..

I don't know if the naming of the DB update file is correct. it does work like that, but would you prefer some date prefix? which date?