### PR TITLE
Market price adaptation mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,28 +16,54 @@ ALTER TABLE `auctionhousebot` RENAME TO `mod_auctionhousebot`;
 ## Description
 
 An auction house bot for the best core: AzerothCore.
+This mod works by selling and bidding auctions in the factions auction house. It can be instructed to do both the operations independently.
 
 ## Installation
 
 ```
-1. Simply place the module under the `modules` directory of your AzerothCore source. 
-1. Import the SQL manually to the right Database (auth, world or characters) or with the `db_assembler.sh` (if `include.sh` provided).
+1. Simply place the module under the `modules` directory of your AzerothCore source.
+1. Import the SQL manually to the right Database (auth, world or characters).
 1. Re-run cmake and launch a clean build of AzerothCore.
 ```
-
-## Edit module configuration (optional)
-
-If you need to change the module configuration, go to your server configuration folder (where your `worldserver` or `worldserver.exe` is)
-rename the file mod_ahbot.conf.dist to mod_ahbot.conf and edit it.
 
 ## Usage
 
 Edit the module configuration and add a player account ID and a character ID.
 This character will sell and buy items in the auction house so give him a good name.
+If you only specify the account ID, all the characters created within that account will be involved in selling and bidding on the markets.
+
+Specify what operation must be performed (`EnableSeller`, `EnableBuyer` or both).
 
 Notes:
 - The account used does not need any security level and can be a player account.
 - The character used by the ahbot is not meant to be used ingame. If you use it to browse the auction house, you might have issues like "Searching for items..." displaying forever.
+
+## Edit module configuration (optional)
+
+If you need to change the module configuration, go to your server configuration folder (where your `worldserver` or `worldserver.exe` is)
+rename the file mod_ahbot.conf.dist to mod_ahbot.conf and edit it. This will change the overall behavior of the bot.
+
+If you need to change a more specific value (for example the quotas of item sold), you will need to update values int the `mod_auctionhousebot` table or use the command line.
+
+The default quotas of all the auction houses for trade goods are:
+- Gray = 0
+- White = 27
+- Green = 12
+- Blue = 10
+- Purple = 1
+- Orange = 0
+- Yellow = 0
+
+The default quotas of all the auction houses for non trade goods items are:
+- Gray = 0
+- White = 10
+- Green = 30
+- Blue = 8
+- Purple = 2
+- Orange = 0
+- Yellow = 0
+
+The sum of the percentage for these categories must always be 100, or otherwise the defaults values will be used and the modifications will not be accepted.
 
 ## Credits
 

--- a/conf/mod_ahbot.conf.dist
+++ b/conf/mod_ahbot.conf.dist
@@ -62,6 +62,8 @@
 #    AuctionHouseBot.ConsiderOnlyBotAuctions
 #        Ignore player auctions and consider only bot ones when keeping track of the numer of auctions in place.
 #        This allow to keep a background noise in the market even when lot of players are in.
+#        If this is not set, players acutions are counted in the valid auctions and you will need to greatly increase the maxitems SQL values to
+#        allow the bot to operate on the market. If this is set the players auctions will not be considered.
 #    Default 0 (False)
 #
 #    AuctionHouseBot.DuplicatesCount

--- a/conf/mod_ahbot.conf.dist
+++ b/conf/mod_ahbot.conf.dist
@@ -47,6 +47,10 @@
 #        Should the Buyer use BuyPrice or SellPrice to determine Bid Prices
 #    Default 0 (use SellPrice)
 #
+#    AuctionHouseBot.UseMarketPriceForSeller
+#        Should the Seller use the market price for its auctions?
+#    Default 0 (disabled)
+#
 #    Auction House Bot character data
 #        AuctionHouseBot.Account is the account number
 #         (in realmd->account table) of the player you want to run
@@ -83,7 +87,6 @@
 #        2 = shorts, auctions lasts within an hour
 #    Default 1
 #
-#
 ###############################################################################
 
 AuctionHouseBot.DEBUG = 0
@@ -98,6 +101,7 @@ AuctionHouseBot.EnableSeller = 0
 AuctionHouseBot.EnableBuyer = 0
 AuctionHouseBot.UseBuyPriceForSeller = 0
 AuctionHouseBot.UseBuyPriceForBuyer = 0
+AuctionHouseBot.UseMarketPriceForSeller = 0
 AuctionHouseBot.Account = 0
 AuctionHouseBot.GUID = 0
 AuctionHouseBot.ItemsPerCycle = 200

--- a/conf/mod_ahbot.conf.dist
+++ b/conf/mod_ahbot.conf.dist
@@ -51,6 +51,13 @@
 #        Should the Seller use the market price for its auctions?
 #    Default 0 (disabled)
 #
+#    AuctionHouseBot.MarketResetThreshold
+#        How many auctions of the same item are necessary before the plain priceis adopted.
+#        Before reaching this threshold, the price increase/decrease according to an heuristic.
+#        Set this variable to a lower value to have a fast reacting market price,
+#        to an high value to smooth the oscillations in prices.
+#    Default 25
+#
 #    Auction House Bot character data
 #        AuctionHouseBot.Account is the account number
 #         (in realmd->account table) of the player you want to run
@@ -102,6 +109,7 @@ AuctionHouseBot.EnableBuyer = 0
 AuctionHouseBot.UseBuyPriceForSeller = 0
 AuctionHouseBot.UseBuyPriceForBuyer = 0
 AuctionHouseBot.UseMarketPriceForSeller = 0
+AuctionHouseBot.MarketResetThreshold = 25
 AuctionHouseBot.Account = 0
 AuctionHouseBot.GUID = 0
 AuctionHouseBot.ItemsPerCycle = 200

--- a/data/sql/db-world/mod_auctionhousebot.sql
+++ b/data/sql/db-world/mod_auctionhousebot.sql
@@ -1,3 +1,7 @@
+--
+-- Main configuration for the auction houses
+--
+
 DROP TABLE IF EXISTS `mod_auctionhousebot`;
 CREATE TABLE `mod_auctionhousebot` (
   `auctionhouse` int(11) NOT NULL DEFAULT '0' COMMENT 'mapID of the auctionhouse.',
@@ -65,20 +69,30 @@ CREATE TABLE `mod_auctionhousebot` (
   PRIMARY KEY (`auctionhouse`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 
-DROP TABLE IF EXISTS `mod_auctionhousebot_disabled_items`;
-CREATE TABLE `mod_auctionhousebot_disabled_items` (
-  `item` mediumint(8) unsigned NOT NULL,
-  PRIMARY KEY (`item`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+--
+-- AHBot auction houses default configuration values
+--
 
--- AHBot auctionhouse configuration
 INSERT INTO `mod_auctionhousebot` (`auctionhouse`, `name`, `minitems`, `maxitems`, `percentgreytradegoods`, `percentwhitetradegoods`, `percentgreentradegoods`, `percentbluetradegoods`, `percentpurpletradegoods`, `percentorangetradegoods`, `percentyellowtradegoods`, `percentgreyitems`, `percentwhiteitems`, `percentgreenitems`, `percentblueitems`, `percentpurpleitems`, `percentorangeitems`, `percentyellowitems`, `minpricegrey`, `maxpricegrey`, `minpricewhite`, `maxpricewhite`, `minpricegreen`, `maxpricegreen`, `minpriceblue`, `maxpriceblue`, `minpricepurple`, `maxpricepurple`, `minpriceorange`, `maxpriceorange`, `minpriceyellow`, `maxpriceyellow`, `minbidpricegrey`, `maxbidpricegrey`, `minbidpricewhite`, `maxbidpricewhite`, `minbidpricegreen`, `maxbidpricegreen`, `minbidpriceblue`, `maxbidpriceblue`, `minbidpricepurple`, `maxbidpricepurple`, `minbidpriceorange`, `maxbidpriceorange`, `minbidpriceyellow`, `maxbidpriceyellow`, `maxstackgrey`, `maxstackwhite`, `maxstackgreen`, `maxstackblue`, `maxstackpurple`, `maxstackorange`, `maxstackyellow`, `buyerpricegrey`, `buyerpricewhite`, `buyerpricegreen`, `buyerpriceblue`, `buyerpricepurple`, `buyerpriceorange`, `buyerpriceyellow`, `buyerbiddinginterval`, `buyerbidsperinterval`)
 VALUES
 (2,'Alliance',250,250,0,27,12,10,1,0,0,0,10,30,8,2,0,0,100,150,150,250,800,1400,1250,1750,2250,4550,3250,5550,5250,6550,70,100,70,100,80,100,75,100,80,100,80,100,80,100,0,0,3,2,1,1,1,1,3,5,12,15,20,22,1,1),
 (6,'Horde',250,250,0,27,12,10,1,0,0,0,10,30,8,2,0,0,100,150,150,250,800,1400,1250,1750,2250,4550,3250,5550,5250,6550,70,100,70,100,80,100,75,100,80,100,80,100,80,100,0,0,3,2,1,1,1,1,3,5,12,15,20,22,1,1),
 (7,'Neutral',250,250,0,27,12,10,1,0,0,0,10,30,8,2,0,0,100,150,150,250,800,1400,1250,1750,2250,4550,3250,5550,5250,6550,70,100,70,100,80,100,75,100,80,100,80,100,80,100,0,0,3,2,1,1,1,1,3,5,12,15,20,22,1,1);
 
--- Items unavailable to players
+--
+-- Items blacklist
+--
+
+DROP TABLE IF EXISTS `mod_auctionhousebot_disabled_items`;
+CREATE TABLE `mod_auctionhousebot_disabled_items` (
+  `item` mediumint(8) unsigned NOT NULL,
+  PRIMARY KEY (`item`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+
+--
+-- Blacklist default values
+--
+
 INSERT INTO `mod_auctionhousebot_disabled_items`
 VALUES
 (17), (3895), (1700), (862), (4196), (3934), (2275), (4213), (4988), (4989), (4990), (4110), (4111), (4116), (3463), (3068),

--- a/src/AuctionHouseBotAuctionHouseScript.cpp
+++ b/src/AuctionHouseBotAuctionHouseScript.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016+ AzerothCore <www.azerothcore.org>, released under GNU AGPL v3 license: https://github.com/azerothcore/azerothcore-wotlk/blob/master/LICENSE-AGPL3
+ * Copyright (C) 2016+ AzerothCore <www.azerothcore.org>, released under GNU AGPL v3 license: https://github.com/azerothcore/azerothcore-wotlk/blob/master/LICENSE
  */
 
 #include "AuctionHouseMgr.h"

--- a/src/AuctionHouseBotAuctionHouseScript.cpp
+++ b/src/AuctionHouseBotAuctionHouseScript.cpp
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2016+ AzerothCore <www.azerothcore.org>, released under GNU AGPL v3 license: https://github.com/azerothcore/azerothcore-wotlk/blob/master/LICENSE-AGPL3
+ */
+
 #include "AuctionHouseMgr.h"
 
 #include "AuctionHouseBot.h"

--- a/src/AuctionHouseBotAuctionHouseScript.cpp
+++ b/src/AuctionHouseBotAuctionHouseScript.cpp
@@ -3,6 +3,7 @@
  */
 
 #include "AuctionHouseMgr.h"
+#include "GameTime.h"
 
 #include "AuctionHouseBot.h"
 #include "AuctionHouseBotCommon.h"
@@ -142,9 +143,8 @@ void AHBot_AuctionHouseScript::OnAuctionAdd(AuctionHouseObject* /*ah*/, AuctionE
 
 void AHBot_AuctionHouseScript::OnAuctionRemove(AuctionHouseObject* /*ah*/, AuctionEntry* auction)
 {
-
     // 
-    // The the configuration for the auction house
+    // Get the configuration for the auction house
     // 
 
     AuctionHouseEntry const* ahEntry = sAuctionHouseStore.LookupEntry(auction->GetHouseId());
@@ -202,6 +202,64 @@ void AHBot_AuctionHouseScript::OnAuctionRemove(AuctionHouseObject* /*ah*/, Aucti
     }
 
     config->DecItemCounts(prototype->Class, prototype->Quality);
+}
+
+void AHBot_AuctionHouseScript::OnAuctionSuccessful(AuctionHouseObject* /*ah*/, AuctionEntry* auction)
+{
+    // 
+    // Get the configuration for the auction house
+    // 
+
+    AuctionHouseEntry const* ahEntry = sAuctionHouseStore.LookupEntry(auction->GetHouseId());
+    AHBConfig*               config  = gNeutralConfig;
+
+    if (ahEntry)
+    {
+        if (ahEntry->houseId == AUCTIONHOUSE_ALLIANCE)
+        {
+            config = gAllianceConfig;
+        }
+        else if (ahEntry->houseId == AUCTIONHOUSE_HORDE)
+        {
+            config = gHordeConfig;
+        }
+    }
+
+    // 
+    // If the auction has been won, it means that it has been accepted by the market.
+    // Use the buyout as a reference since the price for the bid is downgraded during selling.
+    // 
+
+    config->UpdateItemStats(auction->item_template, auction->itemCount, auction->buyout);
+}
+
+void AHBot_AuctionHouseScript::OnAuctionExpire(AuctionHouseObject* /*ah*/, AuctionEntry* auction)
+{
+    // 
+    // Get the configuration for the auction house
+    // 
+
+    AuctionHouseEntry const* ahEntry = sAuctionHouseStore.LookupEntry(auction->GetHouseId());
+    AHBConfig*               config  = gNeutralConfig;
+
+    if (ahEntry)
+    {
+        if (ahEntry->houseId == AUCTIONHOUSE_ALLIANCE)
+        {
+            config = gAllianceConfig;
+        }
+        else if (ahEntry->houseId == AUCTIONHOUSE_HORDE)
+        {
+            config = gHordeConfig;
+        }
+    }
+
+    // 
+    // If the auction expired, then it means that the bid was unwanted by the market.
+    // Bid price is usually less or equal to the buyout, so this likely will bring the price down.
+    // 
+
+    config->UpdateItemStats(auction->item_template, auction->itemCount, auction->bid);
 }
 
 void AHBot_AuctionHouseScript::OnBeforeAuctionHouseMgrUpdate()

--- a/src/AuctionHouseBotAuctionHouseScript.h
+++ b/src/AuctionHouseBotAuctionHouseScript.h
@@ -21,8 +21,10 @@ public:
     void OnBeforeAuctionHouseMgrSendAuctionExpiredMail   (AuctionHouseMgr* auctionHouseMgr, AuctionEntry* auction, Player* owner, uint32& owner_accId, bool& sendNotification, bool& sendMail) override;
     void OnBeforeAuctionHouseMgrSendAuctionOutbiddedMail (AuctionHouseMgr* auctionHouseMgr, AuctionEntry* auction, Player* oldBidder, uint32& oldBidder_accId, Player* newBidder, uint32& newPrice, bool& sendNotification, bool& sendMail) override;
 
-    void OnAuctionAdd   (AuctionHouseObject* ah, AuctionEntry* auction) override;
-    void OnAuctionRemove(AuctionHouseObject* ah, AuctionEntry* auction) override;
+    void OnAuctionAdd       (AuctionHouseObject* ah, AuctionEntry* auction) override;
+    void OnAuctionRemove    (AuctionHouseObject* ah, AuctionEntry* auction) override;
+    void OnAuctionSuccessful(AuctionHouseObject* ah, AuctionEntry* auction) override;
+    void OnAuctionExpire    (AuctionHouseObject* ah, AuctionEntry* auction) override;
 
     void OnBeforeAuctionHouseMgrUpdate() override;
 };

--- a/src/AuctionHouseBotAuctionHouseScript.h
+++ b/src/AuctionHouseBotAuctionHouseScript.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016+ AzerothCore <www.azerothcore.org>, released under GNU AGPL v3 license: https://github.com/azerothcore/azerothcore-wotlk/blob/master/LICENSE-AGPL3
+ * Copyright (C) 2016+ AzerothCore <www.azerothcore.org>, released under GNU AGPL v3 license: https://github.com/azerothcore/azerothcore-wotlk/blob/master/LICENSE
  */
 
 #ifndef AUCTION_HOUSE_BOT_AUCTION_HOUSE_SCRIPT_H

--- a/src/AuctionHouseBotCommon.cpp
+++ b/src/AuctionHouseBotCommon.cpp
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2016+ AzerothCore <www.azerothcore.org>, released under GNU AGPL v3 license: https://github.com/azerothcore/azerothcore-wotlk/blob/master/LICENSE-AGPL3
+ */
+
 #include "AuctionHouseBot.h"
 #include "AuctionHouseBotCommon.h"
 #include "AuctionHouseBotConfig.h"

--- a/src/AuctionHouseBotCommon.cpp
+++ b/src/AuctionHouseBotCommon.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016+ AzerothCore <www.azerothcore.org>, released under GNU AGPL v3 license: https://github.com/azerothcore/azerothcore-wotlk/blob/master/LICENSE-AGPL3
+ * Copyright (C) 2016+ AzerothCore <www.azerothcore.org>, released under GNU AGPL v3 license: https://github.com/azerothcore/azerothcore-wotlk/blob/master/LICENSE
  */
 
 #include "AuctionHouseBot.h"

--- a/src/AuctionHouseBotCommon.h
+++ b/src/AuctionHouseBotCommon.h
@@ -79,6 +79,7 @@ enum class AHBotCommand : uint32
 {
     buyer,
     seller,
+    useMarketPrice,
 
     ahexpire,
     minitems,

--- a/src/AuctionHouseBotConfig.cpp
+++ b/src/AuctionHouseBotConfig.cpp
@@ -1949,6 +1949,7 @@ void AHBConfig::Initialize(std::set<uint32> botsIds)
 {
     InitializeFromFile();
     InitializeFromSql(botsIds);
+    InitializeBins();
 }
 
 void AHBConfig::InitializeFromFile()
@@ -3259,13 +3260,14 @@ void AHBConfig::InitializeBins()
     // Perform reporting and the last check: if no items are disabled or in the whitelist clear the bin making the selling useless
     // 
 
-    LOG_INFO("module", "Configuration for ah {}", AHID);
+    LOG_INFO("module", "===== AHBot ====================");
+    LOG_INFO("module", "AHBot: Configuration for ah {}", AHID);
 
     if (SellerWhiteList.size() == 0)
     {
         if (DisableItemStore.size() == 0)
         {
-            LOG_ERROR("module", "No items are disabled or in the whitelist! Selling will be disabled!");
+            LOG_ERROR("module", "AHBot: No items are disabled or in the whitelist! Selling will be disabled!");
 
             GreyTradeGoodsBin.clear();
             WhiteTradeGoodsBin.clear();
@@ -3287,30 +3289,27 @@ void AHBConfig::InitializeBins()
             return;
         }
 
-        LOG_INFO("module", "{} disabled items", uint32(DisableItemStore.size()));
+        LOG_INFO("module", "AHBot: {} disabled items", uint32(DisableItemStore.size()));
     }
     else
     {
-        LOG_INFO("module", "Using a whitelist of {} items", uint32(SellerWhiteList.size()));
+        LOG_INFO("module", "AHBot: Using a whitelist of {} items", uint32(SellerWhiteList.size()));
     }
 
-    // if (DebugOutConfig)
-    // {
-        LOG_INFO("module", "loaded {} grey   trade goods", uint32(GreyTradeGoodsBin.size()));
-        LOG_INFO("module", "loaded {} white  trade goods", uint32(WhiteTradeGoodsBin.size()));
-        LOG_INFO("module", "loaded {} green  trade goods", uint32(GreenTradeGoodsBin.size()));
-        LOG_INFO("module", "loaded {} blue   trade goods", uint32(BlueTradeGoodsBin.size()));
-        LOG_INFO("module", "loaded {} purple trade goods", uint32(PurpleTradeGoodsBin.size()));
-        LOG_INFO("module", "loaded {} orange trade goods", uint32(OrangeTradeGoodsBin.size()));
-        LOG_INFO("module", "loaded {} yellow trade goods", uint32(YellowTradeGoodsBin.size()));
-        LOG_INFO("module", "loaded {} grey   items"      , uint32(GreyItemsBin.size()));
-        LOG_INFO("module", "loaded {} white  items"      , uint32(WhiteItemsBin.size()));
-        LOG_INFO("module", "loaded {} green  items"      , uint32(GreenItemsBin.size()));
-        LOG_INFO("module", "loaded {} blue   items"      , uint32(BlueItemsBin.size()));
-        LOG_INFO("module", "loaded {} purple items"      , uint32(PurpleItemsBin.size()));
-        LOG_INFO("module", "loaded {} orange items"      , uint32(OrangeItemsBin.size()));
-        LOG_INFO("module", "loaded {} yellow items"      , uint32(YellowItemsBin.size()));
-    // }
+    LOG_INFO("module", "AHBot: loaded {} grey   trade goods", uint32(GreyTradeGoodsBin.size()));
+    LOG_INFO("module", "AHBot: loaded {} white  trade goods", uint32(WhiteTradeGoodsBin.size()));
+    LOG_INFO("module", "AHBot: loaded {} green  trade goods", uint32(GreenTradeGoodsBin.size()));
+    LOG_INFO("module", "AHBot: loaded {} blue   trade goods", uint32(BlueTradeGoodsBin.size()));
+    LOG_INFO("module", "AHBot: loaded {} purple trade goods", uint32(PurpleTradeGoodsBin.size()));
+    LOG_INFO("module", "AHBot: loaded {} orange trade goods", uint32(OrangeTradeGoodsBin.size()));
+    LOG_INFO("module", "AHBot: loaded {} yellow trade goods", uint32(YellowTradeGoodsBin.size()));
+    LOG_INFO("module", "AHBot: loaded {} grey   items"      , uint32(GreyItemsBin.size()));
+    LOG_INFO("module", "AHBot: loaded {} white  items"      , uint32(WhiteItemsBin.size()));
+    LOG_INFO("module", "AHBot: loaded {} green  items"      , uint32(GreenItemsBin.size()));
+    LOG_INFO("module", "AHBot: loaded {} blue   items"      , uint32(BlueItemsBin.size()));
+    LOG_INFO("module", "AHBot: loaded {} purple items"      , uint32(PurpleItemsBin.size()));
+    LOG_INFO("module", "AHBot: loaded {} orange items"      , uint32(OrangeItemsBin.size()));
+    LOG_INFO("module", "AHBot: loaded {} yellow items"      , uint32(YellowItemsBin.size()));
 }
 
 std::set<uint32> AHBConfig::getCommaSeparatedIntegers(std::string text)

--- a/src/AuctionHouseBotConfig.cpp
+++ b/src/AuctionHouseBotConfig.cpp
@@ -3260,7 +3260,6 @@ void AHBConfig::InitializeBins()
     // Perform reporting and the last check: if no items are disabled or in the whitelist clear the bin making the selling useless
     // 
 
-    LOG_INFO("module", "===== AHBot ====================");
     LOG_INFO("module", "AHBot: Configuration for ah {}", AHID);
 
     if (SellerWhiteList.size() == 0)

--- a/src/AuctionHouseBotConfig.cpp
+++ b/src/AuctionHouseBotConfig.cpp
@@ -1974,12 +1974,11 @@ void AHBConfig::UpdateItemStats(uint32 id, uint32 stackSize, uint64 buyout)
         itemsCount[id]++;
 
         //
-        // Reset the statistics at about every 100 buyout to force adapt to the market price
-        // This can cause spikes if this auction in particular is unbalanced, but adds
-        // some movement into the market that can make it an interesting opportunity.
+        // Reset the statistics to force adapt to the market price.
+        // Adds a little of randomness by adding/removing a range of 9 to the threshold.
         //
 
-        if (itemsCount[id] > 100 + (urand(1, 19) - 10))
+        if (itemsCount[id] > MarketResetThreshold + (urand(1, 19) - 10))
         {
             itemsCount[id] = 1;
             itemsSum[id]   = perUnit;
@@ -2040,6 +2039,7 @@ void AHBConfig::InitializeFromFile()
     SellMethod                     = sConfigMgr->GetOption<bool>  ("AuctionHouseBot.UseBuyPriceForSeller"   , false);
     BuyMethod                      = sConfigMgr->GetOption<bool>  ("AuctionHouseBot.UseBuyPriceForBuyer"    , false);
     SellAtMarketPrice              = sConfigMgr->GetOption<bool>  ("AuctionHouseBot.UseMarketPriceForSeller", false);
+    MarketResetThreshold           = sConfigMgr->GetOption<uint32>("AuctionHouseBot.MarketResetThreshold"   , 25);
     DuplicatesCount                = sConfigMgr->GetOption<uint32>("AuctionHouseBot.DuplicatesCount"        , 0);
     DivisibleStacks                = sConfigMgr->GetOption<bool>  ("AuctionHouseBot.DivisibleStacks"        , false);
     ElapsingTimeClass              = sConfigMgr->GetOption<uint32>("AuctionHouseBot.DuplicatesCount"        , 1);

--- a/src/AuctionHouseBotConfig.h
+++ b/src/AuctionHouseBotConfig.h
@@ -183,6 +183,7 @@ public:
     bool   BuyMethod;
     bool   SellMethod;
     bool   SellAtMarketPrice;
+    uint32 MarketResetThreshold;
     bool   ConsiderOnlyBotAuctions;
     uint32 ItemsPerCycle;
 

--- a/src/AuctionHouseBotConfig.h
+++ b/src/AuctionHouseBotConfig.h
@@ -20,6 +20,7 @@
 #ifndef AUCTION_HOUSE_BOT_CONFIG_H
 #define AUCTION_HOUSE_BOT_CONFIG_H
 
+#include <map>
 #include <set>
 #include <string>
 
@@ -142,6 +143,14 @@ private:
     uint32 orangeItems;
     uint32 yellowItems;
 
+    // 
+    // Per-item statistics
+    //
+
+    std::map<uint32, uint32> itemsCount;
+    std::map<uint32, uint64> itemsSum;
+    std::map<uint32, uint64> itemsPrice;
+
     void   InitializeFromFile();
     void   InitializeFromSql(std::set<uint32> botsIds);
 
@@ -173,6 +182,7 @@ public:
     bool   AHBBuyer;
     bool   BuyMethod;
     bool   SellMethod;
+    bool   SellAtMarketPrice;
     bool   ConsiderOnlyBotAuctions;
     uint32 ItemsPerCycle;
 
@@ -343,6 +353,9 @@ public:
     uint32 TotalItemCounts   ();
 
     uint32 GetItemCounts     (uint32 color);
+
+    void   UpdateItemStats   (uint32 id, uint32 stackSize, uint64 buyout);
+    uint64 GetItemPrice      (uint32 id);
 };
 
 //

--- a/src/AuctionHouseBotMailScript.cpp
+++ b/src/AuctionHouseBotMailScript.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016+ AzerothCore <www.azerothcore.org>, released under GNU AGPL v3 license: https://github.com/azerothcore/azerothcore-wotlk/blob/master/LICENSE-AGPL3
+ * Copyright (C) 2016+ AzerothCore <www.azerothcore.org>, released under GNU AGPL v3 license: https://github.com/azerothcore/azerothcore-wotlk/blob/master/LICENSE
  */
 
 #include "AuctionHouseBot.h"

--- a/src/AuctionHouseBotMailScript.cpp
+++ b/src/AuctionHouseBotMailScript.cpp
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2016+ AzerothCore <www.azerothcore.org>, released under GNU AGPL v3 license: https://github.com/azerothcore/azerothcore-wotlk/blob/master/LICENSE-AGPL3
+ */
+
 #include "AuctionHouseBot.h"
 #include "AuctionHouseBotCommon.h"
 #include "AuctionHouseBotMailScript.h"

--- a/src/AuctionHouseBotMailScript.h
+++ b/src/AuctionHouseBotMailScript.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016+ AzerothCore <www.azerothcore.org>, released under GNU AGPL v3 license: https://github.com/azerothcore/azerothcore-wotlk/blob/master/LICENSE-AGPL3
+ * Copyright (C) 2016+ AzerothCore <www.azerothcore.org>, released under GNU AGPL v3 license: https://github.com/azerothcore/azerothcore-wotlk/blob/master/LICENSE
  */
 
 #ifndef AUCTION_HOUSE_BOT_MAIL_SCRIPT_H

--- a/src/AuctionHouseBotScript.cpp
+++ b/src/AuctionHouseBotScript.cpp
@@ -2,15 +2,10 @@
  * Copyright (C) 2016+ AzerothCore <www.azerothcore.org>, released under GNU AGPL v3 license: https://github.com/azerothcore/azerothcore-wotlk/blob/master/LICENSE-AGPL3
  */
 
-// #include "ScriptMgr.h"
 #include "AuctionHouseBot.h"
 #include "AuctionHouseBotAuctionHouseScript.h"
 #include "AuctionHouseBotMailScript.h"
 #include "AuctionHouseBotWorldScript.h"
-// #include "Log.h"
-// #include "Mail.h"
-// #include "Player.h"
-// #include "WorldSession.h"
 
 // =============================================================================
 // This provides the effective startup of the module by istanciating the scripts

--- a/src/AuctionHouseBotScript.cpp
+++ b/src/AuctionHouseBotScript.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016+ AzerothCore <www.azerothcore.org>, released under GNU AGPL v3 license: https://github.com/azerothcore/azerothcore-wotlk/blob/master/LICENSE-AGPL3
+ * Copyright (C) 2016+ AzerothCore <www.azerothcore.org>, released under GNU AGPL v3 license: https://github.com/azerothcore/azerothcore-wotlk/blob/master/LICENSE
  */
 
 #include "AuctionHouseBot.h"

--- a/src/AuctionHouseBotWorldScript.cpp
+++ b/src/AuctionHouseBotWorldScript.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016+ AzerothCore <www.azerothcore.org>, released under GNU AGPL v3 license: https://github.com/azerothcore/azerothcore-wotlk/blob/master/LICENSE-AGPL3
+ * Copyright (C) 2016+ AzerothCore <www.azerothcore.org>, released under GNU AGPL v3 license: https://github.com/azerothcore/azerothcore-wotlk/blob/master/LICENSE
  */
 
 #include "Config.h"

--- a/src/AuctionHouseBotWorldScript.cpp
+++ b/src/AuctionHouseBotWorldScript.cpp
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2016+ AzerothCore <www.azerothcore.org>, released under GNU AGPL v3 license: https://github.com/azerothcore/azerothcore-wotlk/blob/master/LICENSE-AGPL3
+ */
+
 #include "Config.h"
 #include "Log.h"
 
@@ -84,14 +88,6 @@ void AHBot_WorldScript::OnBeforeConfigLoad(bool /*reload*/)
         LOG_ERROR("server.loading", "AHBot: no characters registered for account {}", account);
         return;
     }
-
-    //
-    // Preparare the global configuration for all factions using the configuration just read
-    //
-
-    gAllianceConfig->Initialize(gBotsId);
-    gHordeConfig->Initialize   (gBotsId);
-    gNeutralConfig->Initialize (gBotsId);
 }
 
 void AHBot_WorldScript::OnStartup()
@@ -99,12 +95,12 @@ void AHBot_WorldScript::OnStartup()
     LOG_INFO("server.loading", "Initialize AuctionHouseBot...");
 
     //
-    // Initialize the configuration items bins here, when items has been handled by the object manager
+    // Initialize the configuration
     //
 
-    gAllianceConfig->InitializeBins();
-    gHordeConfig->InitializeBins   ();
-    gNeutralConfig->InitializeBins ();
+    gAllianceConfig->Initialize(gBotsId);
+    gHordeConfig->Initialize   (gBotsId);
+    gNeutralConfig->Initialize (gBotsId);
 
     //
     // Starts the amount of bots read furing the configuration phase

--- a/src/AuctionHouseBotWorldScript.h
+++ b/src/AuctionHouseBotWorldScript.h
@@ -13,6 +13,10 @@
 
 class AHBot_WorldScript : public WorldScript
 {
+private:
+    void DeleteBots();
+    void PopulateBots();
+
 public:
     AHBot_WorldScript();
 

--- a/src/AuctionHouseBotWorldScript.h
+++ b/src/AuctionHouseBotWorldScript.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016+ AzerothCore <www.azerothcore.org>, released under GNU AGPL v3 license: https://github.com/azerothcore/azerothcore-wotlk/blob/master/LICENSE-AGPL3
+ * Copyright (C) 2016+ AzerothCore <www.azerothcore.org>, released under GNU AGPL v3 license: https://github.com/azerothcore/azerothcore-wotlk/blob/master/LICENSE
  */
 
 #ifndef AUCTION_HOUSE_BOT_WORLD_SCRIPT_H

--- a/src/ah_bot_loader.cpp
+++ b/src/ah_bot_loader.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016+ AzerothCore <www.azerothcore.org>, released under GNU AGPL v3 license: https://github.com/azerothcore/azerothcore-wotlk/blob/master/LICENSE-AGPL3
+ * Copyright (C) 2016+ AzerothCore <www.azerothcore.org>, released under GNU AGPL v3 license: https://github.com/azerothcore/azerothcore-wotlk/blob/master/LICENSE
  * Copyright (C) 2021+ WarheadCore <https://github.com/WarheadCore>
  */
 

--- a/src/cs_ah_bot.cpp
+++ b/src/cs_ah_bot.cpp
@@ -35,6 +35,51 @@ using namespace Acore::ChatCommands;
 
 class ah_bot_commandscript : public CommandScript
 {
+private:
+    static ItemQualities stringToItemQualities(const char* name, int length)
+    {
+        // 
+        // Translates a string into ItemQualities enum
+        // 
+
+        if (strncmp(name, "grey", length) == 0)
+        {
+            return ITEM_QUALITY_POOR;
+        }
+
+        if (strncmp(name, "white", length) == 0)
+        {
+            return ITEM_QUALITY_NORMAL;
+        }
+
+        if (strncmp(name, "green", length) == 0)
+        {
+            return ITEM_QUALITY_UNCOMMON;
+        }
+
+        if (strncmp(name, "blue", length) == 0)
+        {
+            return ITEM_QUALITY_RARE;
+        }
+
+        if (strncmp(name, "purple", length) == 0)
+        {
+            return ITEM_QUALITY_EPIC;
+        }
+
+        if (strncmp(name, "orange", length) == 0)
+        {
+            return ITEM_QUALITY_LEGENDARY;
+        }
+
+        if (strncmp(name, "yellow", length) == 0)
+        {
+            return ITEM_QUALITY_ARTIFACT;
+        }
+
+        return static_cast<ItemQualities>(-1); // Invalid
+    }
+
 public:
     ah_bot_commandscript() : CommandScript("ah_bot_commandscript")
     {
@@ -63,50 +108,6 @@ public:
 
             return false;
         }
-
-        //
-        // Support function the item quality
-        //
-
-        auto qualityStringToEnum = [](const char* qualityName, int maxCount)
-        {
-            if (strncmp(qualityName, "grey", maxCount) == 0)
-            {
-                return ITEM_QUALITY_POOR;
-            }
-
-            if (strncmp(qualityName, "white", maxCount) == 0)
-            {
-                return ITEM_QUALITY_NORMAL;
-            }
-
-            if (strncmp(qualityName, "green", maxCount) == 0)
-            {
-                return ITEM_QUALITY_UNCOMMON;
-            }
-
-            if (strncmp(qualityName, "blue", maxCount) == 0)
-            {
-                return ITEM_QUALITY_RARE;
-            }
-
-            if (strncmp(qualityName, "purple", maxCount) == 0)
-            {
-                return ITEM_QUALITY_EPIC;
-            }
-
-            if (strncmp(qualityName, "orange", maxCount) == 0)
-            {
-                return ITEM_QUALITY_LEGENDARY;
-            }
-
-            if (strncmp(qualityName, "yellow", maxCount) == 0)
-            {
-                return ITEM_QUALITY_ARTIFACT;
-            }
-
-            return static_cast<ItemQualities>(-1); // Invalid
-        };
 
         //
         // Commands which does not requires an AH
@@ -148,6 +149,23 @@ public:
 
             return true;
         }
+        else if (strncmp(opt, "usemarketprice", l) == 0)
+        {
+            char* param1 = strtok(NULL, " ");
+
+            if (!param1)
+            {
+                handler->PSendSysMessage("Syntax is: ahbotoptions useMarketPrice $state (0 off 1 on)");
+                return false;
+            }
+
+            for (AuctionHouseBot* bot : gBots)
+            {
+                bot->Commands(AHBotCommand::useMarketPrice, 0, 0, param1);
+            }
+
+            return true;
+        }
 
         //
         // Retrieve the auction house type
@@ -177,9 +195,7 @@ public:
 
         if (!opt)
         {
-            handler->PSendSysMessage("Invalid syntax");
-            handler->PSendSysMessage("Try ahbotoptions help to see a list of options.");
-
+            handler->PSendSysMessage("Invalid syntax; the auction house id must be 2, 6 or 7");
             return false;
         }
 
@@ -192,6 +208,7 @@ public:
             handler->PSendSysMessage("AHBot commands:");
             handler->PSendSysMessage("buyer - enable/disable buyer");
             handler->PSendSysMessage("seller - enable/disabler seller");
+            handler->PSendSysMessage("usemarketprice - enable/disabler selling at market price");
             handler->PSendSysMessage("ahexpire - remove all bot auctions");
             handler->PSendSysMessage("minitems - set min auctions");
             handler->PSendSysMessage("maxitems - set max auctions");
@@ -230,7 +247,7 @@ public:
                 return false;
             }
 
-            for (AuctionHouseBot* bot: gBots)
+            for (AuctionHouseBot* bot : gBots)
             {
                 bot->Commands(AHBotCommand::minitems, ahMapID, 0, param1);
             }
@@ -277,15 +294,15 @@ public:
                 return false;
             }
 
-            uint32 greytg       = uint32(strtoul(param1, NULL, 0));
-            uint32 whitetg      = uint32(strtoul(param2, NULL, 0));
-            uint32 greentg      = uint32(strtoul(param3, NULL, 0));
-            uint32 bluetg       = uint32(strtoul(param4, NULL, 0));
-            uint32 purpletg     = uint32(strtoul(param5, NULL, 0));
-            uint32 orangetg     = uint32(strtoul(param6, NULL, 0));
-            uint32 yellowtg     = uint32(strtoul(param7, NULL, 0));
-            uint32 greyi        = uint32(strtoul(param8, NULL, 0));
-            uint32 whitei       = uint32(strtoul(param9, NULL, 0));
+            uint32 greytg       = uint32(strtoul(param1 , NULL, 0));
+            uint32 whitetg      = uint32(strtoul(param2 , NULL, 0));
+            uint32 greentg      = uint32(strtoul(param3 , NULL, 0));
+            uint32 bluetg       = uint32(strtoul(param4 , NULL, 0));
+            uint32 purpletg     = uint32(strtoul(param5 , NULL, 0));
+            uint32 orangetg     = uint32(strtoul(param6 , NULL, 0));
+            uint32 yellowtg     = uint32(strtoul(param7 , NULL, 0));
+            uint32 greyi        = uint32(strtoul(param8 , NULL, 0));
+            uint32 whitei       = uint32(strtoul(param9 , NULL, 0));
             uint32 greeni       = uint32(strtoul(param10, NULL, 0));
             uint32 bluei        = uint32(strtoul(param11, NULL, 0));
             uint32 purplei      = uint32(strtoul(param12, NULL, 0));
@@ -347,7 +364,7 @@ public:
                 return false;
             }
 
-            auto quality = qualityStringToEnum(param1, l);
+            auto quality = stringToItemQualities(param1, l);
 
             if (quality != static_cast<ItemQualities>(-1))
             {
@@ -373,7 +390,7 @@ public:
                 return false;
             }
 
-            auto quality = qualityStringToEnum(param1, l);
+            auto quality = stringToItemQualities(param1, l);
 
             if (quality != static_cast<ItemQualities>(-1))
             {
@@ -407,7 +424,7 @@ public:
                 return false;
             }
 
-            auto quality = qualityStringToEnum(param1, l);
+            auto quality = stringToItemQualities(param1, l);
 
             if (quality != static_cast<ItemQualities>(-1))
             {
@@ -441,7 +458,7 @@ public:
                 return false;
             }
 
-            auto quality = qualityStringToEnum(param1, l);
+            auto quality = stringToItemQualities(param1, l);
 
             if (quality != static_cast<ItemQualities>(-1))
             {
@@ -474,7 +491,7 @@ public:
             //    return false;
             // }
 
-            auto quality = qualityStringToEnum(param1, l);
+            auto quality = stringToItemQualities(param1, l);
 
             if (quality != static_cast<ItemQualities>(-1))
             {
@@ -500,7 +517,7 @@ public:
                 return false;
             }
 
-            auto quality = qualityStringToEnum(param1, l);
+            auto quality = stringToItemQualities(param1, l);
 
             if (quality != static_cast<ItemQualities>(-1))
             {


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Minor fixes to the initialization stage to correct the moment where certain operation are performed
- Introduced a mechanism which allows the seller bot to adapt the price of the item to the one of the market. Auctions are monitored and a statistic about the price per unit is stored inside the AH configuration. When a new stock is sold, the bot will use this price instead of the item hardcoded one. The bot can be configured to adapt quickly or slowly to the market oscillations. This new feature is **backward compatible**, as it is disabled by default. If disabled, the default selling strategy is used.
- Bot in game commands extended to enable/disable this new mechanism on the fly
- Extended the README

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- No open issues are fixed by this pull; just providing new functionalities

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
- No sources

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Compile without errors with the last version of the core ([2024-09-07](https://github.com/azerothcore/azerothcore-wotlk/commit/e7448f29862e67b25bffbbd8a011c4f0d6b53cb0))
- I've performed preliminary tests by having the bots compete against themselves on the market. While this is not a real test in an environment with real persons, this allowed to test the core mechanism for the statistics collection and the selling part. It would be good to have some feedback on real auction markets with hundreds of players.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Enable the bot and configure it for a standard behavior
2. Configure the bot to adapt to market prices with `AuctionHouseBot.UseMarketPriceForSeller = 1`
3. Enable the debugging of the configuration `AuctionHouseBot.DEBUG_CONFIG = 1`
4. Enter in the game before buying hover the auction with the mouse to see the price per item of that auction. Write down the price somewhere and buyout it.
5. On the server console you will see a log like `Updating market price item=2450, price=49`
6. If you buy again the same item with a different price per unit, you will see the item price change, fluctuating up and down depending on the market mood for that item
7. Changing `AuctionHouseBot.MarketResetThreshold` allows you to setup a slower or faster adaptation threshold
