### PR TITLE
fix: bug only finds a single auction #129 from azerothcore\mod-ah-bot

### DIFF
--- a/src/AuctionHouseBot.cpp
+++ b/src/AuctionHouseBot.cpp
@@ -164,7 +164,6 @@ uint32 AuctionHouseBot::getNofAuctions(AHBConfig* config, AuctionHouseObject* au
         if (guid == Aentry->owner)
         {
             count++;
-            break;
         }
     }
 


### PR DESCRIPTION
https://github.com/azerothcore/mod-ah-bot/issues/129

remove break in AuctionHouseBot::getNofAuctions to avoid always returning 1 auction when using ConsiderOnlyBotAuctions true

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
remove the "break" in AuctionHouseBot::getNofAuctions()

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes  Bug: Only finds a single auction #129 
https://github.com/azerothcore/mod-ah-bot/issues/129

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- tested windows and linux
- build correctly on all platform


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. use ConsiderOnlyBotAuctions true in config
2. Check that AuctionHouseBot::getNofAuctions returns the correct number of action from the AH
