### PR TITLE
Fix issue 123 Fix Bug: wrong variable read from the config

### DIFF
--- a/src/AuctionHouseBot.cpp
+++ b/src/AuctionHouseBot.cpp
@@ -164,7 +164,6 @@ uint32 AuctionHouseBot::getNofAuctions(AHBConfig* config, AuctionHouseObject* au
         if (guid == Aentry->owner)
         {
             count++;
-            break;
         }
     }
 

--- a/src/AuctionHouseBotConfig.cpp
+++ b/src/AuctionHouseBotConfig.cpp
@@ -2045,7 +2045,7 @@ void AHBConfig::InitializeFromFile()
     MarketResetThreshold           = sConfigMgr->GetOption<uint32>("AuctionHouseBot.MarketResetThreshold"   , 25);
     DuplicatesCount                = sConfigMgr->GetOption<uint32>("AuctionHouseBot.DuplicatesCount"        , 0);
     DivisibleStacks                = sConfigMgr->GetOption<bool>  ("AuctionHouseBot.DivisibleStacks"        , false);
-    ElapsingTimeClass              = sConfigMgr->GetOption<uint32>("AuctionHouseBot.DuplicatesCount"        , 1);
+    ElapsingTimeClass              = sConfigMgr->GetOption<uint32>("AuctionHouseBot.ElapsingTimeClass"      , 1);
     ConsiderOnlyBotAuctions        = sConfigMgr->GetOption<bool>  ("AuctionHouseBot.ConsiderOnlyBotAuctions", false);
     ItemsPerCycle                  = sConfigMgr->GetOption<uint32>("AuctionHouseBot.ItemsPerCycle"          , 200);
 


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Fix typo when reading config file
- 

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/mod-ah-bot/issues/123

## SOURCE:
https://github.com/azerothcore/mod-ah-bot/issues/123

## Tests Performed:
- Config read correct value from config


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Check config read correct value for ElapsingTimeClass
2.
3.
