### PR TITLE
Restock AH without a server restart or config reload

### DIFF
--- a/src/AuctionHouseBotAuctionHouseScript.cpp
+++ b/src/AuctionHouseBotAuctionHouseScript.cpp
@@ -80,9 +80,9 @@ void AHBot_AuctionHouseScript::OnBeforeAuctionHouseMgrSendAuctionOutbiddedMail(
 
 void AHBot_AuctionHouseScript::OnAuctionAdd(AuctionHouseObject* /*ah*/, AuctionEntry* auction)
 {
-    // 
+    //
     // The the configuration for the auction house
-    // 
+    //
 
     AuctionHouseEntry const* ahEntry = sAuctionMgr->GetAuctionHouseEntryFromHouse(auction->GetHouseId());
     AHBConfig*               config  = gNeutralConfig;
@@ -99,9 +99,9 @@ void AHBot_AuctionHouseScript::OnAuctionAdd(AuctionHouseObject* /*ah*/, AuctionE
         }
     }
 
-    // 
+    //
     // Consider only those auctions handled by the bots
-    // 
+    //
 
     if (config->ConsiderOnlyBotAuctions)
     {
@@ -143,12 +143,9 @@ void AHBot_AuctionHouseScript::OnAuctionAdd(AuctionHouseObject* /*ah*/, AuctionE
 
 void AHBot_AuctionHouseScript::OnAuctionRemove(AuctionHouseObject* /*ah*/, AuctionEntry* auction)
 {
-    // 
     // Get the configuration for the auction house
-    // 
-
     AuctionHouseEntry const* ahEntry = sAuctionMgr->GetAuctionHouseEntryFromHouse(auction->GetHouseId());
-    AHBConfig*               config  = gNeutralConfig;
+    AHBConfig* config = gNeutralConfig;
 
     if (ahEntry)
     {
@@ -162,10 +159,7 @@ void AHBot_AuctionHouseScript::OnAuctionRemove(AuctionHouseObject* /*ah*/, Aucti
         }
     }
 
-    // 
     // Consider only those auctions handled by the bots
-    // 
-
     if (config->ConsiderOnlyBotAuctions)
     {
         if (gBotsId.find(auction->owner.GetCounter()) != gBotsId.end())
@@ -174,11 +168,10 @@ void AHBot_AuctionHouseScript::OnAuctionRemove(AuctionHouseObject* /*ah*/, Aucti
         }
     }
 
-    //
     // Verify if we can operate on the item
-    //
-
     Item* pItem = sAuctionMgr->GetAItem(auction->item_guid);
+
+    ItemTemplate const* prototype = sObjectMgr->GetItemTemplate(auction->item_template);
 
     if (!pItem)
     {
@@ -187,28 +180,29 @@ void AHBot_AuctionHouseScript::OnAuctionRemove(AuctionHouseObject* /*ah*/, Aucti
             LOG_ERROR("module", "AHBot: Item {} doesn't exist, perhaps bought already?", auction->item_guid.ToString());
         }
 
+        // Decrement item counts even if the item does not exist
+        if (prototype)
+        {
+            config->DecItemCounts(prototype->Class, prototype->Quality);
+        }
+
         return;
     }
-
-    //
-    // Decrements
-    //
-
-    ItemTemplate const* prototype = sObjectMgr->GetItemTemplate(auction->item_template);
 
     if (config->DebugOut)
     {
         LOG_INFO("module", "AHBot: ah={}, item={}, count={}", auction->GetHouseId(), auction->item_template, config->GetItemCounts(prototype->Quality));
     }
 
+    // Decrement item counts
     config->DecItemCounts(prototype->Class, prototype->Quality);
 }
 
 void AHBot_AuctionHouseScript::OnAuctionSuccessful(AuctionHouseObject* /*ah*/, AuctionEntry* auction)
 {
-    // 
+    //
     // Get the configuration for the auction house
-    // 
+    //
 
     AuctionHouseEntry const* ahEntry = sAuctionMgr->GetAuctionHouseEntryFromHouse(auction->GetHouseId());
     AHBConfig*               config  = gNeutralConfig;
@@ -225,19 +219,19 @@ void AHBot_AuctionHouseScript::OnAuctionSuccessful(AuctionHouseObject* /*ah*/, A
         }
     }
 
-    // 
+    //
     // If the auction has been won, it means that it has been accepted by the market.
     // Use the buyout as a reference since the price for the bid is downgraded during selling.
-    // 
+    //
 
     config->UpdateItemStats(auction->item_template, auction->itemCount, auction->buyout);
 }
 
 void AHBot_AuctionHouseScript::OnAuctionExpire(AuctionHouseObject* /*ah*/, AuctionEntry* auction)
 {
-    // 
+    //
     // Get the configuration for the auction house
-    // 
+    //
 
     AuctionHouseEntry const* ahEntry = sAuctionMgr->GetAuctionHouseEntryFromHouse(auction->GetHouseId());
     AHBConfig*               config  = gNeutralConfig;
@@ -254,10 +248,10 @@ void AHBot_AuctionHouseScript::OnAuctionExpire(AuctionHouseObject* /*ah*/, Aucti
         }
     }
 
-    // 
+    //
     // If the auction expired, then it means that the bid was unwanted by the market.
     // Bid price is usually less or equal to the buyout, so this likely will bring the price down.
-    // 
+    //
 
     config->UpdateItemStats(auction->item_template, auction->itemCount, auction->bid);
 }

--- a/src/AuctionHouseBotAuctionHouseScript.cpp
+++ b/src/AuctionHouseBotAuctionHouseScript.cpp
@@ -254,6 +254,16 @@ void AHBot_AuctionHouseScript::OnAuctionExpire(AuctionHouseObject* /*ah*/, Aucti
     //
 
     config->UpdateItemStats(auction->item_template, auction->itemCount, auction->bid);
+
+    // Decrement item counts
+    ItemTemplate const* prototype = sObjectMgr->GetItemTemplate(auction->item_template);
+
+    if (config->DebugOut)
+    {
+        LOG_INFO("module", "AHBot: ah={}, item={}, count={}", auction->GetHouseId(), auction->item_template, config->GetItemCounts(prototype->Quality));
+    }
+
+    config->DecItemCounts(prototype->Class, prototype->Quality);
 }
 
 void AHBot_AuctionHouseScript::OnBeforeAuctionHouseMgrUpdate()


### PR DESCRIPTION
## Changes Proposed:
- [decrease item counts if auction expires](https://github.com/azerothcore/mod-ah-bot/commit/17f05d672dd0f2dd08875ef25907ae3c44cf127c)
- [Fix decreasing of items in AH if item doesn't exist](https://github.com/azerothcore/mod-ah-bot/commit/2b3b403a51f8b4ab59c6ed8dced2402652571315)

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #126 
- Closes #122 
- Closes #130

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Build passes (tested on windows)
- Server starts
- Server is running without crashing
- Restock observed for a week with auctions lasting "short" periods


## How to Test the Changes:

1. Pull PR branch
2. build
4. run with activated tracing and logging
5. observe items being added when the auction count is below configured values
