### PR TITLE
Fix various issues in code like AH restocking and proper item ratio due to not uising good enums values in AuctionHouseBot::Sell

### DIFF
--- a/data/sql/db-world/mod_auctionhousebot.sql
+++ b/data/sql/db-world/mod_auctionhousebot.sql
@@ -75,9 +75,9 @@ CREATE TABLE `mod_auctionhousebot` (
 
 INSERT INTO `mod_auctionhousebot` (`auctionhouse`, `name`, `minitems`, `maxitems`, `percentgreytradegoods`, `percentwhitetradegoods`, `percentgreentradegoods`, `percentbluetradegoods`, `percentpurpletradegoods`, `percentorangetradegoods`, `percentyellowtradegoods`, `percentgreyitems`, `percentwhiteitems`, `percentgreenitems`, `percentblueitems`, `percentpurpleitems`, `percentorangeitems`, `percentyellowitems`, `minpricegrey`, `maxpricegrey`, `minpricewhite`, `maxpricewhite`, `minpricegreen`, `maxpricegreen`, `minpriceblue`, `maxpriceblue`, `minpricepurple`, `maxpricepurple`, `minpriceorange`, `maxpriceorange`, `minpriceyellow`, `maxpriceyellow`, `minbidpricegrey`, `maxbidpricegrey`, `minbidpricewhite`, `maxbidpricewhite`, `minbidpricegreen`, `maxbidpricegreen`, `minbidpriceblue`, `maxbidpriceblue`, `minbidpricepurple`, `maxbidpricepurple`, `minbidpriceorange`, `maxbidpriceorange`, `minbidpriceyellow`, `maxbidpriceyellow`, `maxstackgrey`, `maxstackwhite`, `maxstackgreen`, `maxstackblue`, `maxstackpurple`, `maxstackorange`, `maxstackyellow`, `buyerpricegrey`, `buyerpricewhite`, `buyerpricegreen`, `buyerpriceblue`, `buyerpricepurple`, `buyerpriceorange`, `buyerpriceyellow`, `buyerbiddinginterval`, `buyerbidsperinterval`)
 VALUES
-(2,'Alliance',250,250,0,27,12,10,1,0,0,0,10,30,8,2,0,0,100,150,150,250,800,1400,1250,1750,2250,4550,3250,5550,5250,6550,70,100,70,100,80,100,75,100,80,100,80,100,80,100,0,0,3,2,1,1,1,1,3,5,12,15,20,22,1,1),
-(6,'Horde',250,250,0,27,12,10,1,0,0,0,10,30,8,2,0,0,100,150,150,250,800,1400,1250,1750,2250,4550,3250,5550,5250,6550,70,100,70,100,80,100,75,100,80,100,80,100,80,100,0,0,3,2,1,1,1,1,3,5,12,15,20,22,1,1),
-(7,'Neutral',250,250,0,27,12,10,1,0,0,0,10,30,8,2,0,0,100,150,150,250,800,1400,1250,1750,2250,4550,3250,5550,5250,6550,70,100,70,100,80,100,75,100,80,100,80,100,80,100,0,0,3,2,1,1,1,1,3,5,12,15,20,22,1,1);
+(2,'Alliance',2500,2500,0,27,12,10,1,0,0,0,10,30,8,2,0,0,100,150,150,250,800,1400,1250,1750,2250,4550,3250,5550,5250,6550,70,100,70,100,80,100,75,100,80,100,80,100,80,100,0,0,3,2,1,1,1,1,3,5,12,15,20,22,1,1),
+(6,'Horde',0,0,0,27,12,10,1,0,0,0,10,30,8,2,0,0,100,150,150,250,800,1400,1250,1750,2250,4550,3250,5550,5250,6550,70,100,70,100,80,100,75,100,80,100,80,100,80,100,0,0,3,2,1,1,1,1,3,5,12,15,20,22,1,1),
+(7,'Neutral',0,0,0,27,12,10,1,0,0,0,10,30,8,2,0,0,100,150,150,250,800,1400,1250,1750,2250,4550,3250,5550,5250,6550,70,100,70,100,80,100,75,100,80,100,80,100,80,100,0,0,3,2,1,1,1,1,3,5,12,15,20,22,1,1);
 
 --
 -- Items blacklist

--- a/data/sql/db-world/mod_auctionhousebot.sql
+++ b/data/sql/db-world/mod_auctionhousebot.sql
@@ -75,9 +75,9 @@ CREATE TABLE `mod_auctionhousebot` (
 
 INSERT INTO `mod_auctionhousebot` (`auctionhouse`, `name`, `minitems`, `maxitems`, `percentgreytradegoods`, `percentwhitetradegoods`, `percentgreentradegoods`, `percentbluetradegoods`, `percentpurpletradegoods`, `percentorangetradegoods`, `percentyellowtradegoods`, `percentgreyitems`, `percentwhiteitems`, `percentgreenitems`, `percentblueitems`, `percentpurpleitems`, `percentorangeitems`, `percentyellowitems`, `minpricegrey`, `maxpricegrey`, `minpricewhite`, `maxpricewhite`, `minpricegreen`, `maxpricegreen`, `minpriceblue`, `maxpriceblue`, `minpricepurple`, `maxpricepurple`, `minpriceorange`, `maxpriceorange`, `minpriceyellow`, `maxpriceyellow`, `minbidpricegrey`, `maxbidpricegrey`, `minbidpricewhite`, `maxbidpricewhite`, `minbidpricegreen`, `maxbidpricegreen`, `minbidpriceblue`, `maxbidpriceblue`, `minbidpricepurple`, `maxbidpricepurple`, `minbidpriceorange`, `maxbidpriceorange`, `minbidpriceyellow`, `maxbidpriceyellow`, `maxstackgrey`, `maxstackwhite`, `maxstackgreen`, `maxstackblue`, `maxstackpurple`, `maxstackorange`, `maxstackyellow`, `buyerpricegrey`, `buyerpricewhite`, `buyerpricegreen`, `buyerpriceblue`, `buyerpricepurple`, `buyerpriceorange`, `buyerpriceyellow`, `buyerbiddinginterval`, `buyerbidsperinterval`)
 VALUES
-(2,'Alliance',2500,2500,0,27,12,10,1,0,0,0,10,30,8,2,0,0,100,150,150,250,800,1400,1250,1750,2250,4550,3250,5550,5250,6550,70,100,70,100,80,100,75,100,80,100,80,100,80,100,0,0,3,2,1,1,1,1,3,5,12,15,20,22,1,1),
-(6,'Horde',0,0,0,27,12,10,1,0,0,0,10,30,8,2,0,0,100,150,150,250,800,1400,1250,1750,2250,4550,3250,5550,5250,6550,70,100,70,100,80,100,75,100,80,100,80,100,80,100,0,0,3,2,1,1,1,1,3,5,12,15,20,22,1,1),
-(7,'Neutral',0,0,0,27,12,10,1,0,0,0,10,30,8,2,0,0,100,150,150,250,800,1400,1250,1750,2250,4550,3250,5550,5250,6550,70,100,70,100,80,100,75,100,80,100,80,100,80,100,0,0,3,2,1,1,1,1,3,5,12,15,20,22,1,1);
+(2,'Alliance',250,250,0,27,12,10,1,0,0,0,10,30,8,2,0,0,100,150,150,250,800,1400,1250,1750,2250,4550,3250,5550,5250,6550,70,100,70,100,80,100,75,100,80,100,80,100,80,100,0,0,3,2,1,1,1,1,3,5,12,15,20,22,1,1),
+(6,'Horde',250,250,0,27,12,10,1,0,0,0,10,30,8,2,0,0,100,150,150,250,800,1400,1250,1750,2250,4550,3250,5550,5250,6550,70,100,70,100,80,100,75,100,80,100,80,100,80,100,0,0,3,2,1,1,1,1,3,5,12,15,20,22,1,1),
+(7,'Neutral',250,250,0,27,12,10,1,0,0,0,10,30,8,2,0,0,100,150,150,250,800,1400,1250,1750,2250,4550,3250,5550,5250,6550,70,100,70,100,80,100,75,100,80,100,80,100,80,100,0,0,3,2,1,1,1,1,3,5,12,15,20,22,1,1);
 
 --
 -- Items blacklist

--- a/src/AuctionHouseBot.cpp
+++ b/src/AuctionHouseBot.cpp
@@ -164,7 +164,6 @@ uint32 AuctionHouseBot::getNofAuctions(AHBConfig* config, AuctionHouseObject* au
         if (guid == Aentry->owner)
         {
             count++;
-            break;
         }
     }
 

--- a/src/AuctionHouseBot.cpp
+++ b/src/AuctionHouseBot.cpp
@@ -575,10 +575,8 @@ void AuctionHouseBot::Sell(Player* AHBplayer, AHBConfig* config)
 
         if (config->DebugOutSeller)
         {
-            LOG_ERROR("module", "AHBot [{}]: Auctions above minimum", _id);
+            LOG_TRACE("module", "AHBot [{}]: Auctions above minimum", _id);
         }
-
-        return;
     }
 
     if (nbOfAuctions >= maxTotalItems)
@@ -587,7 +585,7 @@ void AuctionHouseBot::Sell(Player* AHBplayer, AHBConfig* config)
 
         if (config->DebugOutSeller)
         {
-            LOG_ERROR("module", "AHBot [{}]: Auctions at or above maximum", _id);
+            LOG_TRACE("module", "AHBot [{}]: Auctions at or above maximum", _id);
         }
 
         return;

--- a/src/AuctionHouseBot.cpp
+++ b/src/AuctionHouseBot.cpp
@@ -254,7 +254,9 @@ void AuctionHouseBot::Buy(Player* AHBplayer, AHBConfig* config, WorldSession* se
         std::vector<uint32>::iterator itBegin = auctionsGuidsToConsider.begin();
         //std::advance(it, randomIndex);
 
-        AuctionEntry* auction = auctionHouse->GetAuction(auctionsGuidsToConsider.at(randomIndex));
+        uint32 auctionID = auctionsGuidsToConsider.at(randomIndex);
+
+        AuctionEntry* auction = auctionHouse->GetAuction(auctionID);
 
         //
         // Prevent to bid again on the same auction
@@ -266,7 +268,7 @@ void AuctionHouseBot::Buy(Player* AHBplayer, AHBConfig* config, WorldSession* se
         {
             if (config->DebugOutBuyer)
             {
-                LOG_ERROR("module", "AHBot [{}]: item {} Possible entry to buy/bid from AH pool is invalid, this should not happen, moving on next auciton");
+                LOG_ERROR("module", "AHBot [{}]: Auction id: {} Possible entry to buy/bid from AH pool is invalid, this should not happen, moving on next auciton", _id, auctionID);
             }
             continue;
         }

--- a/src/AuctionHouseBotAuctionHouseScript.cpp
+++ b/src/AuctionHouseBotAuctionHouseScript.cpp
@@ -227,7 +227,7 @@ void AHBot_AuctionHouseScript::OnAuctionSuccessful(AuctionHouseObject* /*ah*/, A
 
 }
 
-void AHBot_AuctionHouseScript::OnAuctionExpire(AuctionHouseObject* ah, AuctionEntry* auction)
+void AHBot_AuctionHouseScript::OnAuctionExpire(AuctionHouseObject* /*ah*/, AuctionEntry* auction)
 {
     //
     // Get the configuration for the auction house

--- a/src/AuctionHouseBotAuctionHouseScript.cpp
+++ b/src/AuctionHouseBotAuctionHouseScript.cpp
@@ -85,7 +85,7 @@ void AHBot_AuctionHouseScript::OnAuctionAdd(AuctionHouseObject* /*ah*/, AuctionE
     // 
 
     AuctionHouseEntry const* ahEntry = sAuctionMgr->GetAuctionHouseEntryFromHouse(auction->GetHouseId());
-    AHBConfig*               config  = gNeutralConfig;
+    AHBConfig* config  = gNeutralConfig;
 
     if (ahEntry)
     {
@@ -121,7 +121,7 @@ void AHBot_AuctionHouseScript::OnAuctionAdd(AuctionHouseObject* /*ah*/, AuctionE
     {
         if (config->DebugOut)
         {
-            LOG_ERROR("module", "AHBot: Item {} doesn't exist, perhaps bought already?", auction->item_guid.ToString());
+            LOG_ERROR("module", "AHBot: Item {} for entryiD={} doesn't exist, perhaps bought already?", auction->item_guid.ToString(), auction->Id);
         }
 
         return;
@@ -133,12 +133,12 @@ void AHBot_AuctionHouseScript::OnAuctionAdd(AuctionHouseObject* /*ah*/, AuctionE
 
     ItemTemplate const* prototype = sObjectMgr->GetItemTemplate(auction->item_template);
 
+    config->IncItemCounts(prototype->Class, prototype->Quality);
+
     if (config->DebugOut)
     {
-        LOG_INFO("module", "AHBot: ah={}, item={}, count={}", auction->GetHouseId(), auction->item_template, config->GetItemCounts(prototype->Quality));
-    }
-
-    config->IncItemCounts(prototype->Class, prototype->Quality);
+        LOG_INFO("module", "AHBot: Auction Added ah={}, auctionId={}, totalAHItems = {}", AuctionHouseId(ahEntry->houseId), auction->Id, config->TotalItemCounts());
+    }    
 }
 
 // this is called after the auction has been removed from the DB
@@ -149,7 +149,7 @@ void AHBot_AuctionHouseScript::OnAuctionRemove(AuctionHouseObject* /*ah*/, Aucti
     // 
 
     AuctionHouseEntry const* ahEntry = sAuctionMgr->GetAuctionHouseEntryFromHouse(auction->GetHouseId());
-    AHBConfig*               config  = gNeutralConfig;
+    AHBConfig* config = gNeutralConfig;
 
     if (ahEntry)
     {
@@ -183,7 +183,7 @@ void AHBot_AuctionHouseScript::OnAuctionRemove(AuctionHouseObject* /*ah*/, Aucti
         config->DecItemCounts(prototype->Class, prototype->Quality);
         if (config->DebugOut)
         {
-            LOG_INFO("module", "AHBot: Item was removed ah={}, item={}, count={}", auction->GetHouseId(), auction->item_template, config->GetItemCounts(prototype->Quality));
+            LOG_INFO("module", "AHBot: Auction removed ah={}, auctionId={}, Bot totalAHItems={}", AuctionHouseId(ahEntry->houseId), auction->Id, config->TotalItemCounts());
         }
     }
     else
@@ -204,7 +204,7 @@ void AHBot_AuctionHouseScript::OnAuctionSuccessful(AuctionHouseObject* /*ah*/, A
     // 
 
     AuctionHouseEntry const* ahEntry = sAuctionMgr->GetAuctionHouseEntryFromHouse(auction->GetHouseId());
-    AHBConfig*               config  = gNeutralConfig;
+    AHBConfig* config = gNeutralConfig;
 
     if (ahEntry)
     {
@@ -218,22 +218,34 @@ void AHBot_AuctionHouseScript::OnAuctionSuccessful(AuctionHouseObject* /*ah*/, A
         }
     }
 
+
     // 
     // If the auction has been won, it means that it has been accepted by the market.
     // Use the buyout as a reference since the price for the bid is downgraded during selling.
     // 
 
+    if (config->DebugOut)
+    {
+        LOG_INFO("module", "AHBot: Auction successful ah={}, auctionId={}, Bot totalAHItems={}", AuctionHouseId(ahEntry->houseId), auction->Id, config->TotalItemCounts());
+    }
+
     config->UpdateItemStats(auction->item_template, auction->itemCount, auction->buyout);
+
 }
 
-void AHBot_AuctionHouseScript::OnAuctionExpire(AuctionHouseObject* /*ah*/, AuctionEntry* auction)
+void AHBot_AuctionHouseScript::OnAuctionExpire(AuctionHouseObject* ah, AuctionEntry* auction)
 {
     // 
     // Get the configuration for the auction house
     // 
 
+    if (!auction)
+    {
+        LOG_ERROR("module", "AHBot: AHBot_AuctionHouseScript::OnAuctionExpire invalid AuctionEntry");
+    }
+
     AuctionHouseEntry const* ahEntry = sAuctionMgr->GetAuctionHouseEntryFromHouse(auction->GetHouseId());
-    AHBConfig*               config  = gNeutralConfig;
+    AHBConfig* config = gNeutralConfig;
 
     if (ahEntry)
     {
@@ -259,7 +271,7 @@ void AHBot_AuctionHouseScript::OnAuctionExpire(AuctionHouseObject* /*ah*/, Aucti
 
     if (config->DebugOut)
     {
-        LOG_INFO("module", "AHBot: ah={}, item={}, count={}", auction->GetHouseId(), auction->item_template, config->GetItemCounts(prototype->Quality));
+        LOG_INFO("module", "AHBot: Auction Expired ah={}, auctionId={} Bot totalAHItems={}", AuctionHouseId(ahEntry->houseId), auction->Id, config->TotalItemCounts());
     }
 }
 

--- a/src/AuctionHouseBotAuctionHouseScript.cpp
+++ b/src/AuctionHouseBotAuctionHouseScript.cpp
@@ -180,6 +180,8 @@ void AHBot_AuctionHouseScript::OnAuctionRemove(AuctionHouseObject* /*ah*/, Aucti
 
     Item* pItem = sAuctionMgr->GetAItem(auction->item_guid);
 
+    ItemTemplate const* prototype = sObjectMgr->GetItemTemplate(auction->item_template);
+
     if (!pItem)
     {
         if (config->DebugOut)
@@ -187,14 +189,14 @@ void AHBot_AuctionHouseScript::OnAuctionRemove(AuctionHouseObject* /*ah*/, Aucti
             LOG_ERROR("module", "AHBot: Item {} doesn't exist, perhaps bought already?", auction->item_guid.ToString());
         }
 
+        // Decrement item counts even if the item does not exist
+        if (prototype)
+        {
+            config->DecItemCounts(prototype->Class, prototype->Quality);
+        }
+
         return;
     }
-
-    //
-    // Decrements
-    //
-
-    ItemTemplate const* prototype = sObjectMgr->GetItemTemplate(auction->item_template);
 
     if (config->DebugOut)
     {
@@ -260,6 +262,16 @@ void AHBot_AuctionHouseScript::OnAuctionExpire(AuctionHouseObject* /*ah*/, Aucti
     // 
 
     config->UpdateItemStats(auction->item_template, auction->itemCount, auction->bid);
+
+    // Decrement item counts
+    ItemTemplate const* prototype = sObjectMgr->GetItemTemplate(auction->item_template);
+
+    if (config->DebugOut)
+    {
+        LOG_INFO("module", "AHBot: ah={}, item={}, count={}", auction->GetHouseId(), auction->item_template, config->GetItemCounts(prototype->Quality));
+    }
+
+    config->DecItemCounts(prototype->Class, prototype->Quality);
 }
 
 void AHBot_AuctionHouseScript::OnBeforeAuctionHouseMgrUpdate()

--- a/src/AuctionHouseBotCommon.h
+++ b/src/AuctionHouseBotCommon.h
@@ -71,6 +71,8 @@ class AuctionHouseBot;
 #define AHB_ORANGE_I         12
 #define AHB_YELLOW_I         13
 
+#define AHB_ITEM_TYPE_OFFSET 7
+
 //
 // Chat GM commands
 //

--- a/src/AuctionHouseBotConfig.cpp
+++ b/src/AuctionHouseBotConfig.cpp
@@ -2045,7 +2045,7 @@ void AHBConfig::InitializeFromFile()
     MarketResetThreshold           = sConfigMgr->GetOption<uint32>("AuctionHouseBot.MarketResetThreshold"   , 25);
     DuplicatesCount                = sConfigMgr->GetOption<uint32>("AuctionHouseBot.DuplicatesCount"        , 0);
     DivisibleStacks                = sConfigMgr->GetOption<bool>  ("AuctionHouseBot.DivisibleStacks"        , false);
-    ElapsingTimeClass              = sConfigMgr->GetOption<uint32>("AuctionHouseBot.DuplicatesCount"        , 1);
+    ElapsingTimeClass              = sConfigMgr->GetOption<uint32>("AuctionHouseBot.ElapsingTimeClass"      , 1);
     ConsiderOnlyBotAuctions        = sConfigMgr->GetOption<bool>  ("AuctionHouseBot.ConsiderOnlyBotAuctions", false);
     ItemsPerCycle                  = sConfigMgr->GetOption<uint32>("AuctionHouseBot.ItemsPerCycle"          , 200);
 

--- a/src/AuctionHouseBotConfig.cpp
+++ b/src/AuctionHouseBotConfig.cpp
@@ -201,8 +201,8 @@ AHBConfig::AHBConfig(uint32 ahid, AHBConfig* conf)
     TraceBuyer                     = conf->TraceBuyer;
     AHBSeller                      = conf->AHBSeller;
     AHBBuyer                       = conf->AHBBuyer;
-    BuyMethod                      = conf->BuyMethod;
-    SellMethod                     = conf->SellMethod;
+    UseBuyPriceForBuyer            = conf->UseBuyPriceForBuyer;
+    UseBuyPriceForSeller           = conf->UseBuyPriceForSeller;
     ConsiderOnlyBotAuctions        = conf->ConsiderOnlyBotAuctions;
     ItemsPerCycle                  = conf->ItemsPerCycle;
     Vendor_Items                   = conf->Vendor_Items;
@@ -508,8 +508,8 @@ void AHBConfig::Reset()
     AHBSeller                      = false;
     AHBBuyer                       = false;
 
-    BuyMethod                      = false;
-    SellMethod                     = false;
+    UseBuyPriceForBuyer            = false;
+    UseBuyPriceForSeller           = false;
     SellAtMarketPrice              = false;
     ConsiderOnlyBotAuctions        = false;
     ItemsPerCycle                  = 200;
@@ -1700,58 +1700,114 @@ void AHBConfig::DecItemCounts(uint32 color)
     {
     case AHB_GREY_TG:
         --greyTGoods;
+        if (greyTGoods < 0)
+        {
+            greyTGoods = 0;
+        }
         break;
 
     case AHB_WHITE_TG:
         --whiteTGoods;
+        if (whiteTGoods < 0)
+        {
+            whiteTGoods = 0;
+        }
         break;
 
     case AHB_GREEN_TG:
         --greenTGoods;
+        if (greenTGoods < 0)
+        {
+            greenTGoods = 0;
+        }
         break;
 
     case AHB_BLUE_TG:
         --blueTGoods;
+        if (blueTGoods < 0)
+        {
+            blueTGoods = 0;
+        }
         break;
 
     case AHB_PURPLE_TG:
         --purpleTGoods;
+        if (purpleTGoods < 0)
+        {
+            purpleTGoods = 0;
+        }
         break;
 
     case AHB_ORANGE_TG:
         --orangeTGoods;
+        if (orangeTGoods < 0)
+        {
+            orangeTGoods = 0;
+        }
         break;
 
     case AHB_YELLOW_TG:
         --yellowTGoods;
+        if (yellowTGoods < 0)
+        {
+            yellowTGoods = 0;
+        }
         break;
 
     case AHB_GREY_I:
         --greyItems;
+        if (greyItems < 0)
+        {
+            greyItems = 0;
+        }
         break;
 
     case AHB_WHITE_I:
         --whiteItems;
+        if (whiteItems < 0)
+        {
+            whiteItems = 0;
+        }
         break;
 
     case AHB_GREEN_I:
         --greenItems;
+        if (greenItems < 0)
+        {
+            greenItems = 0;
+        }
         break;
 
     case AHB_BLUE_I:
         --blueItems;
+        if (blueItems < 0)
+        {
+            blueItems = 0;
+        }
         break;
 
     case AHB_PURPLE_I:
         --purpleItems;
+        if (purpleItems < 0)
+        {
+            purpleItems = 0;
+        }
         break;
 
     case AHB_ORANGE_I:
         --orangeItems;
+        if (orangeItems < 0)
+        {
+            orangeItems = 0;
+        }
         break;
 
     case AHB_YELLOW_I:
         --yellowItems;
+        if (yellowItems < 0)
+        {
+            yellowItems = 0;
+        }
         break;
 
     default:
@@ -2039,8 +2095,8 @@ void AHBConfig::InitializeFromFile()
 
     AHBSeller                      = sConfigMgr->GetOption<bool>  ("AuctionHouseBot.EnableSeller"           , false);
     AHBBuyer                       = sConfigMgr->GetOption<bool>  ("AuctionHouseBot.EnableBuyer"            , false);
-    SellMethod                     = sConfigMgr->GetOption<bool>  ("AuctionHouseBot.UseBuyPriceForSeller"   , false);
-    BuyMethod                      = sConfigMgr->GetOption<bool>  ("AuctionHouseBot.UseBuyPriceForBuyer"    , false);
+    UseBuyPriceForSeller           = sConfigMgr->GetOption<bool>  ("AuctionHouseBot.UseBuyPriceForSeller"   , false);
+    UseBuyPriceForBuyer            = sConfigMgr->GetOption<bool>  ("AuctionHouseBot.UseBuyPriceForBuyer"    , false);
     SellAtMarketPrice              = sConfigMgr->GetOption<bool>  ("AuctionHouseBot.UseMarketPriceForSeller", false);
     MarketResetThreshold           = sConfigMgr->GetOption<uint32>("AuctionHouseBot.MarketResetThreshold"   , 25);
     DuplicatesCount                = sConfigMgr->GetOption<uint32>("AuctionHouseBot.DuplicatesCount"        , 0);
@@ -2286,9 +2342,9 @@ void AHBConfig::InitializeFromSql(std::set<uint32> botsIds)
     //
 
     AuctionHouseObject* auctionHouse = sAuctionMgr->GetAuctionsMap(GetAHFID());
-    uint32              auctions     = auctionHouse->Getcount();
+    uint32 numberOfAuctions = auctionHouse->Getcount();
 
-    if (auctions)
+    if (numberOfAuctions > 0)
     {
         for (AuctionHouseObject::AuctionEntryMap::const_iterator itr = auctionHouse->GetAuctionsBegin(); itr != auctionHouse->GetAuctionsEnd(); ++itr)
         {
@@ -2621,7 +2677,7 @@ void AHBConfig::InitializeBins()
         // Exclude items with no possible price
         //
 
-        if (SellMethod)
+        if (UseBuyPriceForSeller)
         {
             if (itr->second.BuyPrice == 0)
             {

--- a/src/AuctionHouseBotConfig.cpp
+++ b/src/AuctionHouseBotConfig.cpp
@@ -1699,114 +1699,100 @@ void AHBConfig::DecItemCounts(uint32 color)
     switch (color)
     {
     case AHB_GREY_TG:
-        --greyTGoods;
-        if (greyTGoods < 0)
+        if (greyTGoods > 0)
         {
-            greyTGoods = 0;
+            --greyTGoods;
         }
         break;
 
     case AHB_WHITE_TG:
-        --whiteTGoods;
-        if (whiteTGoods < 0)
+        if (whiteTGoods > 0)
         {
-            whiteTGoods = 0;
+            --whiteTGoods;
         }
         break;
 
-    case AHB_GREEN_TG:
-        --greenTGoods;
-        if (greenTGoods < 0)
+    case AHB_GREEN_TG:        
+        if (greenTGoods > 0)
         {
-            greenTGoods = 0;
+            --greenTGoods;
         }
         break;
 
     case AHB_BLUE_TG:
-        --blueTGoods;
-        if (blueTGoods < 0)
+        if (blueTGoods > 0)
         {
-            blueTGoods = 0;
+            --blueTGoods;
         }
         break;
 
     case AHB_PURPLE_TG:
-        --purpleTGoods;
-        if (purpleTGoods < 0)
+        if (purpleTGoods > 0)
         {
-            purpleTGoods = 0;
+            --purpleTGoods;
         }
         break;
 
     case AHB_ORANGE_TG:
-        --orangeTGoods;
-        if (orangeTGoods < 0)
+        if (orangeTGoods > 0)
         {
-            orangeTGoods = 0;
+            --orangeTGoods;        
         }
         break;
 
     case AHB_YELLOW_TG:
-        --yellowTGoods;
-        if (yellowTGoods < 0)
+        if (yellowTGoods > 0)
         {
-            yellowTGoods = 0;
+            --yellowTGoods;
         }
         break;
 
     case AHB_GREY_I:
-        --greyItems;
-        if (greyItems < 0)
+        if (greyItems > 0)
         {
-            greyItems = 0;
+            --greyItems;
         }
         break;
 
     case AHB_WHITE_I:
-        --whiteItems;
-        if (whiteItems < 0)
+        if (whiteItems > 0)
         {
-            whiteItems = 0;
+            --whiteItems;
         }
         break;
 
     case AHB_GREEN_I:
-        --greenItems;
-        if (greenItems < 0)
+        if (greenItems > 0)
         {
-            greenItems = 0;
+            --greenItems;
         }
         break;
 
     case AHB_BLUE_I:
-        --blueItems;
-        if (blueItems < 0)
+        if (blueItems > 0)
         {
-            blueItems = 0;
+            --blueItems;
         }
         break;
 
     case AHB_PURPLE_I:
-        --purpleItems;
-        if (purpleItems < 0)
+        if (purpleItems > 0)
         {
-            purpleItems = 0;
+            --purpleItems;
         }
         break;
 
     case AHB_ORANGE_I:
-        --orangeItems;
-        if (orangeItems < 0)
+        if (orangeItems > 0)
         {
-            orangeItems = 0;
+            --orangeItems;
         }
         break;
 
     case AHB_YELLOW_I:
-        --yellowItems;
-        if (yellowItems < 0)
+        if (yellowItems > 0)
         {
-            yellowItems = 0;
+            --yellowItems;
         }
         break;
 

--- a/src/AuctionHouseBotConfig.cpp
+++ b/src/AuctionHouseBotConfig.cpp
@@ -1615,68 +1615,57 @@ void AHBConfig::CalculatePercents()
     }
 }
 
-uint32 AHBConfig::GetMaximum(uint32 color)
+uint32 AHBConfig::GetMaximum(uint32 ahbotItemType)
 {
-    switch (color)
+    switch (ahbotItemType)
     {
     case AHB_GREY_TG:
         return greytgp;
-        break;
 
     case AHB_WHITE_TG:
         return whitetgp;
-        break;
 
     case AHB_GREEN_TG:
         return greentgp;
-        break;
 
     case AHB_BLUE_TG:
         return bluetgp;
-        break;
 
     case AHB_PURPLE_TG:
         return purpletgp;
-        break;
+
     case AHB_ORANGE_TG:
         return orangetgp;
-        break;
 
     case AHB_YELLOW_TG:
         return yellowtgp;
-        break;
 
     case AHB_GREY_I:
         return greyip;
-        break;
 
     case AHB_WHITE_I:
         return whiteip;
-        break;
 
     case AHB_GREEN_I:
         return greenip;
-        break;
 
     case AHB_BLUE_I:
         return blueip;
-        break;
 
     case AHB_PURPLE_I:
         return purpleip;
-        break;
 
     case AHB_ORANGE_I:
         return orangeip;
-        break;
 
     case AHB_YELLOW_I:
         return yellowip;
-        break;
 
     default:
+    {
+        LOG_ERROR("module", "AHBot AHBConfig::GetMaximum() invalid param");
         return 0;
-        break;
+    }
     }
 }
 
@@ -1689,14 +1678,14 @@ void AHBConfig::DecItemCounts(uint32 Class, uint32 Quality)
         break;
 
     default:
-        DecItemCounts(Quality + 7);
+        DecItemCounts(Quality + AHB_ITEM_TYPE_OFFSET);
         break;
     }
 }
 
-void AHBConfig::DecItemCounts(uint32 color)
+void AHBConfig::DecItemCounts(uint32 ahbotItemType)
 {
-    switch (color)
+    switch (ahbotItemType)
     {
     case AHB_GREY_TG:
         if (greyTGoods > 0)
@@ -1815,9 +1804,9 @@ void AHBConfig::IncItemCounts(uint32 Class, uint32 Quality)
     }
 }
 
-void AHBConfig::IncItemCounts(uint32 color)
+void AHBConfig::IncItemCounts(uint32 ahbotItemType)
 {
-    switch (color)
+    switch (ahbotItemType)
     {
     case AHB_GREY_TG:
         ++greyTGoods;

--- a/src/AuctionHouseBotConfig.h
+++ b/src/AuctionHouseBotConfig.h
@@ -180,8 +180,8 @@ public:
 
     bool   AHBSeller;
     bool   AHBBuyer;
-    bool   BuyMethod;
-    bool   SellMethod;
+    bool   UseBuyPriceForBuyer;
+    bool   UseBuyPriceForSeller;
     bool   SellAtMarketPrice;
     uint32 MarketResetThreshold;
     bool   ConsiderOnlyBotAuctions;

--- a/src/AuctionHouseBotConfig.h
+++ b/src/AuctionHouseBotConfig.h
@@ -156,6 +156,9 @@ private:
 
     std::set<uint32> getCommaSeparatedIntegers(std::string text);
 
+    void DecItemCounts(uint32 ahbotItemType);
+    void IncItemCounts(uint32 ahbotItemType);
+
 public:
     //
     // Debugging
@@ -343,13 +346,13 @@ public:
     uint32 GetBidsPerInterval();
 
     void   CalculatePercents ();
-    uint32 GetMaximum        (uint32 color);
-
+    // max number of items of type in AH based on maxItems
+    uint32 GetMaximum        (uint32 ahbotItemType);
+    
     void   DecItemCounts     (uint32 Class, uint32 Quality);
-    void   DecItemCounts     (uint32 color);
 
     void   IncItemCounts     (uint32 Class, uint32 Quality);
-    void   IncItemCounts     (uint32 color);
+
 
     void   ResetItemCounts   ();
     uint32 TotalItemCounts   ();


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Fix AH items going to zero and not restocking until server restart because Bot internal item count was getting out of sync over time. ( since proper server AH parsing is done only at the start )
- Fix wrong categories of items being sold because of errors with using magic numbers instead of defines.
- Fix early exit of Bot Selling items if number of items is above min and not above max when using maxitems != minitems
- Fix AH Bot SQL query when buying items not using correct faction's AH.
- Correctly keep track of auctions in AHBot_AuctionHouseScript when auction expires, sold and are added.
- Bot was not using the proper defines ( like AHB_GREY_I ) AuctionHouseBot::Sell and using hardcoded values that were not the correct one.
- Bot now buys with configured price ratio since item categories are now fixed with using proper defines.
- Added more logging to track issues

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
Restocking items overtime correctly works with proper ratio.
- Closes https://github.com/azerothcore/mod-ah-bot/issues/138


## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Ran server for multiple days. Items ratio and restocking is working correctly.
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1.
2.
3.
