### PR TITLE
Fix integer underflow in buyer algorithm

### DIFF
--- a/src/AuctionHouseBot.cpp
+++ b/src/AuctionHouseBot.cpp
@@ -244,8 +244,11 @@ void AuctionHouseBot::Buy(Player* AHBplayer, AHBConfig* config, WorldSession* se
         LOG_INFO("module", "AHBot [{}]: Considering {} auctions per interval to bid on.", _id, config->GetBidsPerInterval());
     }
 
-    for (uint32 count = 1; count <= config->GetBidsPerInterval(); ++count)
-    {
+    for (
+        uint32 count = 1;
+        count <= config->GetBidsPerInterval() && !auctionsGuidsToConsider.empty();
+        ++count
+    ) {
         //
         // Choose a random auction from possible auctions
         //


### PR DESCRIPTION
## Changes Proposed:
- Fixed vector out-of-bounds access in AHBot buyer functionality

## Issues Addressed:
- The crash occurs due to unsafe vector access in the AHBot buyer functionality, causing a std::out_of_range exception:
`terminate called after throwing an instance of 'std::out_of_range'
  what():  vector::_M_range_check: __n (which is 2968787162) >= this->size() (which is 0)
Caught signal 6`

## Tests Performed:
- Built and tested on AzerothCore commit f332b0714077d7578e9bbe18951cefb330ec5052
- Tested in-game with AHBot buyer functionality enabled
- Verified that the server no longer crashes during AHBot buy operations

## How to Test the Changes:
1. Enable the AHBot module and specifically the buyer functionality.
2. Set bids per interval higher than the actual auction count for each auction house:
   ```
   .ah bidsperinterval 2 4 
   .ah bidsperinterval 6 4 
   .ah bidsperinterval 7 4 
   ```
3. Create test conditions:
   - Ensure there are fewer player auctions than the bidsperinterval count
   - Make sure there are no AHBot-created auctions

4. Wait for the next AHBot cycle and verify:
   - The server doesn't crash during buy operations
   - The buy operations complete successfully