### PR TITLE
Fix: Auction timings

### DIFF
--- a/conf/mod_ahbot.conf.dist
+++ b/conf/mod_ahbot.conf.dist
@@ -89,9 +89,9 @@
 #
 #    AuctionHouseBot.ElapsingTimeClass
 #        The elapsing time for the sold items. There are three classes:
-#        0 = long, auctions lasts from from 1 to 3 days
-#        1 = medium, auctions lasts from 1 to 24 hours
-#        2 = shorts, auctions lasts from 10 to 60 minutes
+#        0 = long, auctions last from from 1 to 3 days
+#        1 = medium, auctions last from 1 to 24 hours
+#        2 = shorts, auctions last from 10 to 60 minutes
 #    Default 1
 #
 ###############################################################################

--- a/conf/mod_ahbot.conf.dist
+++ b/conf/mod_ahbot.conf.dist
@@ -89,7 +89,7 @@
 #
 #    AuctionHouseBot.ElapsingTimeClass
 #        The elapsing time for the sold items. There are three classes:
-#        0 = long, auctions last from from 1 to 3 days
+#        0 = long, auctions last from 1 to 3 days
 #        1 = medium, auctions last from 1 to 24 hours
 #        2 = shorts, auctions last from 10 to 60 minutes
 #    Default 1

--- a/conf/mod_ahbot.conf.dist
+++ b/conf/mod_ahbot.conf.dist
@@ -89,9 +89,9 @@
 #
 #    AuctionHouseBot.ElapsingTimeClass
 #        The elapsing time for the sold items. There are three classes:
-#        0 = long, auctions lasts from one to three days
-#        1 = medium, auctions lasts within a day
-#        2 = shorts, auctions lasts within an hour
+#        0 = long, auctions lasts from from 1 to 3 days
+#        1 = medium, auctions lasts from 1 to 24 hours
+#        2 = shorts, auctions lasts from 10 to 60 minutes
 #    Default 1
 #
 ###############################################################################

--- a/src/AuctionHouseBot.cpp
+++ b/src/AuctionHouseBot.cpp
@@ -132,13 +132,13 @@ uint32 AuctionHouseBot::getElapsedTime(uint32 timeClass)
     switch (timeClass)
     {
     case 2:
-        return urand(1, 5) * 600;   // SHORT = In the range of one hour
+        return urand(1, 6) * 600;   // SHORT = From 10 to 60 minutes
 
     case 1:
-        return urand(1, 23) * 3600; // MEDIUM = In the range of one day
+        return urand(1, 24) * 3600; // MEDIUM = From 1 to 24 hours
 
     default:
-        return urand(1, 3) * 86400; // LONG = More than one day but less than three
+        return urand(24, 72) * 3600; // LONG = From 1 to 3 days
     }
 }
 


### PR DESCRIPTION
New PR due to accidental branch deletion.

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
1. Updates short auctions to actually last up to a full hour.
2. Updates medium auctions to actually last up to a full day.
3. Updates long auctions to be more granular in timings, making them more realistic of player auction times distributions. Instead of them lasting full 1, 2, or 3 days, they now can last anywhere from 24 to 72 hours, with 1 hour increments.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
Ran server on Debian with changed settings. Confirmed some short auctions last up to 60 minutes (up from a max of 50). Confirmed long auctions can last some day and a portion (instead of only full days)


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1.
2.
3.
